### PR TITLE
Refactoring of linear trend models

### DIFF
--- a/etna/transforms/detrend.py
+++ b/etna/transforms/detrend.py
@@ -22,6 +22,8 @@ class _OneSegmentLinearTrendBaseTransform(Transform):
 
         Parameters
         ----------
+        in_column:
+            name of processed column
         regressor:
             instance of sklearn RegressorMixin to predict trend
         """
@@ -127,6 +129,8 @@ class LinearTrendTransform(PerSegmentWrapper):
 
         Parameters
         ----------
+        in_column:
+            name of processed column
         regression_params:
             params that should be used to init LinearRegression
         """
@@ -147,6 +151,8 @@ class TheilSenTrendTransform(PerSegmentWrapper):
 
         Parameters
         ----------
+        in_column:
+            name of processed column
         regression_params:
             params that should be used to init TheilSenRegressor
         """

--- a/etna/transforms/detrend.py
+++ b/etna/transforms/detrend.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pandas as pd
 from sklearn.base import RegressorMixin
 from sklearn.linear_model import LinearRegression
@@ -121,21 +123,21 @@ class _OneSegmentLinearTrendTransform(OneSegmentLinearTrendBaseTransform):
 
         Parameters
         ----------
-        regression_params: Dict[str, Any]
+        regression_params:
             params that should be used to init LinearRegression
         """
         super().__init__(in_column=in_column, regressor=LinearRegression(**regression_params))
 
 
 class _OneSegmentTheilSenTrendTransform(OneSegmentLinearTrendBaseTransform):
-    """Transform for one segment that uses sklearn.linear_model.LinearRegression to find linear trend in data."""
+    """Transform for one segment that uses sklearn.linear_model.TheilSenRegressor to find linear trend in data."""
 
     def __init__(self, in_column, **regression_params):
         """Create instance of _OneSegmentTheilSenTrendTransform.
 
         Parameters
         ----------
-        regression_params: Dict[str, Any]
+        regression_params:
             params that should be used to init TheilSenRegressor
         """
         super().__init__(in_column=in_column, regressor=TheilSenRegressor(**regression_params))
@@ -149,7 +151,7 @@ class LinearTrendTransform(PerSegmentWrapper):
 
         Parameters
         ----------
-        regression_params: Dict[str, Any]
+        regression_params:
             params that should be used to init LinearRegression
         """
         self.in_column = in_column
@@ -161,11 +163,11 @@ class TheilSenTrendTransform(PerSegmentWrapper):
     """Transform that uses sklearn.linear_model.TheilSenRegressor to find linear trend in data."""
 
     def __init__(self, in_column: str, **regression_params):
-        """Create instance of TheilSenTrend.
+        """Create instance of TheilSenTrendTransform.
 
         Parameters
         ----------
-        regression_params: Dict[str, Any]
+        regression_params:
             params that should be used to init TheilSenRegressor
         """
         self.in_column = in_column

--- a/etna/transforms/detrend.py
+++ b/etna/transforms/detrend.py
@@ -39,7 +39,8 @@ class OneSegmentLinearTrendBaseTransform(Transform):
 
         Returns
         -------
-            LinearTrendBaseTransform instance with trained regressor
+        OneSegmentLinearTrendBaseTransform
+            instance with trained regressor
         """
         series_len = len(df)
         x = df.index.to_series()
@@ -62,6 +63,7 @@ class OneSegmentLinearTrendBaseTransform(Transform):
 
         Returns
         -------
+        pd.DataFrame
             residue after trend subtraction
         """
         result = df.copy()
@@ -86,6 +88,7 @@ class OneSegmentLinearTrendBaseTransform(Transform):
 
         Returns
         -------
+        pd.DataFrame
             residue after trend subtraction
         """
         return self.fit(df).transform(df)
@@ -101,6 +104,7 @@ class OneSegmentLinearTrendBaseTransform(Transform):
 
         Returns
         -------
+        pd.DataFrame
             data with reconstructed trend
         """
         result = df.copy()

--- a/etna/transforms/detrend.py
+++ b/etna/transforms/detrend.py
@@ -9,7 +9,7 @@ from etna.transforms.base import PerSegmentWrapper
 from etna.transforms.base import Transform
 
 
-class OneSegmentLinearTrendBaseTransform(Transform):
+class _OneSegmentLinearTrendBaseTransform(Transform):
     """LinearTrendBaseTransform is a base class that implements trend subtraction and reconstruction feature."""
 
     is_categorical = False
@@ -18,7 +18,7 @@ class OneSegmentLinearTrendBaseTransform(Transform):
     def __init__(self, in_column: str, regressor: Optional[RegressorMixin] = None):
         # TODO: add inplace arg
         """
-        Create instance of OneSegmentLinearTrendBaseTransform.
+        Create instance of _OneSegmentLinearTrendBaseTransform.
 
         Parameters
         ----------
@@ -28,7 +28,7 @@ class OneSegmentLinearTrendBaseTransform(Transform):
         self._linear_model = regressor
         self.in_column = in_column
 
-    def fit(self, df: pd.DataFrame) -> "OneSegmentLinearTrendBaseTransform":
+    def fit(self, df: pd.DataFrame) -> "_OneSegmentLinearTrendBaseTransform":
         """
         Fit regression detrend_model with data from df.
 
@@ -39,7 +39,7 @@ class OneSegmentLinearTrendBaseTransform(Transform):
 
         Returns
         -------
-        OneSegmentLinearTrendBaseTransform
+        _OneSegmentLinearTrendBaseTransform
             instance with trained regressor
         """
         series_len = len(df)
@@ -119,34 +119,6 @@ class OneSegmentLinearTrendBaseTransform(Transform):
         return result
 
 
-class _OneSegmentLinearTrendTransform(OneSegmentLinearTrendBaseTransform):
-    """Transform for one segment that uses sklearn.linear_model.LinearRegression to find linear trend in data."""
-
-    def __init__(self, in_column: str, **regression_params):
-        """Create instance of _OneSegmentLinearTrendTransform.
-
-        Parameters
-        ----------
-        regression_params:
-            params that should be used to init LinearRegression
-        """
-        super().__init__(in_column=in_column, regressor=LinearRegression(**regression_params))
-
-
-class _OneSegmentTheilSenTrendTransform(OneSegmentLinearTrendBaseTransform):
-    """Transform for one segment that uses sklearn.linear_model.TheilSenRegressor to find linear trend in data."""
-
-    def __init__(self, in_column, **regression_params):
-        """Create instance of _OneSegmentTheilSenTrendTransform.
-
-        Parameters
-        ----------
-        regression_params:
-            params that should be used to init TheilSenRegressor
-        """
-        super().__init__(in_column=in_column, regressor=TheilSenRegressor(**regression_params))
-
-
 class LinearTrendTransform(PerSegmentWrapper):
     """Transform that uses sklearn.linear_model.LinearRegression to find linear trend in data."""
 
@@ -160,7 +132,11 @@ class LinearTrendTransform(PerSegmentWrapper):
         """
         self.in_column = in_column
         self.regression_params = regression_params
-        super().__init__(transform=_OneSegmentLinearTrendTransform(self.in_column, **self.regression_params))
+        super().__init__(
+            transform=_OneSegmentLinearTrendBaseTransform(
+                in_column=self.in_column, regressor=LinearRegression(**self.regression_params)
+            )
+        )
 
 
 class TheilSenTrendTransform(PerSegmentWrapper):
@@ -176,4 +152,8 @@ class TheilSenTrendTransform(PerSegmentWrapper):
         """
         self.in_column = in_column
         self.regression_params = regression_params
-        super().__init__(transform=_OneSegmentTheilSenTrendTransform(self.in_column, **self.regression_params))
+        super().__init__(
+            transform=_OneSegmentLinearTrendBaseTransform(
+                in_column=self.in_column, regressor=TheilSenRegressor(**self.regression_params)
+            )
+        )

--- a/tests/test_transforms/test_detrend_transform.py
+++ b/tests/test_transforms/test_detrend_transform.py
@@ -3,11 +3,11 @@ import pandas as pd
 import pytest
 
 from etna.datasets.tsdataset import TSDataset
-from etna.transforms.detrend import LinearTrendBaseTransform
+from etna.transforms.detrend import OneSegmentLinearTrendBaseTransform
 from etna.transforms.detrend import LinearTrendTransform
 from etna.transforms.detrend import TheilSenTrendTransform
-from etna.transforms.detrend import _LinearTrendTransform
-from etna.transforms.detrend import _TheilSenTrendTransform
+from etna.transforms.detrend import _OneSegmentLinearTrendTransform
+from etna.transforms.detrend import _OneSegmentTheilSenTrendTransform
 
 DEFAULT_SEGMENT = "segment_1"
 
@@ -23,7 +23,7 @@ def df_two_segments(example_df) -> pd.DataFrame:
 
 
 def _test_fit_transform_one_segment(
-    trend_transform: LinearTrendBaseTransform, df: pd.DataFrame, **comparison_kwargs
+    trend_transform: OneSegmentLinearTrendBaseTransform, df: pd.DataFrame, **comparison_kwargs
 ) -> None:
     """
     Test if residue after trend subtraction is close to zero in one segment.
@@ -31,7 +31,7 @@ def _test_fit_transform_one_segment(
     Parameters
     ----------
     trend_transform:
-        instance of LinearTrendBaseTransform to predict trend with
+        instance of OneSegmentLinearTrendBaseTransform to predict trend with
     df:
         dataframe to predict
     comparison_kwargs:
@@ -63,7 +63,7 @@ def test_fit_transform_linear_trend_one_segment(df_one_segment: pd.DataFrame) ->
     """
     This test checks that LinearRegression predicts correct trend on one segment of slightly noised data.
     """
-    trend_transform = _LinearTrendTransform(in_column="target")
+    trend_transform = _OneSegmentLinearTrendTransform(in_column="target")
     _test_fit_transform_one_segment(trend_transform=trend_transform, df=df_one_segment)
 
 
@@ -71,7 +71,7 @@ def test_fit_transform_theil_sen_trend_one_segment(df_one_segment: pd.DataFrame)
     """
     This test checks that TheilSenRegressor predicts correct trend on one segment of slightly noised data.
     """
-    trend_feature = _TheilSenTrendTransform(
+    trend_feature = _OneSegmentTheilSenTrendTransform(
         in_column="target", n_subsamples=int(len(df_one_segment) / 2), max_iter=3000, tol=1e-4
     )
     _test_fit_transform_one_segment(trend_transform=trend_feature, df=df_one_segment, decimal=0)
@@ -83,7 +83,7 @@ def test_fit_transform_theil_sen_trend_all_data_one_segment(df_one_segment: pd.D
     using all the data to train model.
     """
     # Note that it is a corner case: we use all the data to predict trend
-    trend_feature = _TheilSenTrendTransform(in_column="target", n_subsamples=len(df_one_segment))
+    trend_feature = _OneSegmentTheilSenTrendTransform(in_column="target", n_subsamples=len(df_one_segment))
     _test_fit_transform_one_segment(trend_transform=trend_feature, df=df_one_segment)
 
 
@@ -116,7 +116,7 @@ def test_fit_transform_theil_sen_trend_all_data_two_segments(df_two_segments: pd
 
 
 def _test_inverse_transform_one_segment(
-    trend_transform: LinearTrendBaseTransform, df: pd.DataFrame, **comparison_kwargs
+    trend_transform: OneSegmentLinearTrendBaseTransform, df: pd.DataFrame, **comparison_kwargs
 ) -> None:
     """
     Test that trend_feature can correctly make inverse_transform in one segment.
@@ -158,7 +158,7 @@ def test_inverse_transform_linear_trend_one_segment(df_one_segment: pd.DataFrame
     """
     Test that LinearTrend can correclty make inverse_transform for one segment.
     """
-    trend_feature = _LinearTrendTransform(in_column="target")
+    trend_feature = _OneSegmentLinearTrendTransform(in_column="target")
     _test_inverse_transform_one_segment(trend_transform=trend_feature, df=df_one_segment)
 
 
@@ -166,7 +166,7 @@ def test_inverse_transform_theil_sen_trend_one_segment(df_one_segment: pd.DataFr
     """
     Test that TheilSenRegressor can correclty make inverse_transform for one segment.
     """
-    trend_feature = _TheilSenTrendTransform(in_column="target", n_subsamples=len(df_one_segment))
+    trend_feature = _OneSegmentTheilSenTrendTransform(in_column="target", n_subsamples=len(df_one_segment))
     _test_inverse_transform_one_segment(trend_transform=trend_feature, df=df_one_segment)
 
 

--- a/tests/test_transforms/test_detrend_transform.py
+++ b/tests/test_transforms/test_detrend_transform.py
@@ -3,8 +3,8 @@ import pandas as pd
 import pytest
 
 from etna.datasets.tsdataset import TSDataset
-from etna.transforms.detrend import OneSegmentLinearTrendBaseTransform
 from etna.transforms.detrend import LinearTrendTransform
+from etna.transforms.detrend import OneSegmentLinearTrendBaseTransform
 from etna.transforms.detrend import TheilSenTrendTransform
 from etna.transforms.detrend import _OneSegmentLinearTrendTransform
 from etna.transforms.detrend import _OneSegmentTheilSenTrendTransform


### PR DESCRIPTION
There are some errors in signatures of methods in `etna.transforms.detrend`. There is also some discrepancy in naming classes inside this file with naming in other transforms.