### PR TITLE
ETNA-772

### DIFF
--- a/etna/transforms/power.py
+++ b/etna/transforms/power.py
@@ -1,5 +1,6 @@
 from typing import List
 from typing import Optional
+from typing import Union
 
 from sklearn.preprocessing import PowerTransformer
 
@@ -9,10 +10,12 @@ from etna.transforms.sklearn import SklearnTransform
 class YeoJohnsonTransform(SklearnTransform):
     """YeoJohnsonTransform applies Yeo-Johns transformation to a DataFrame."""
 
-    def __init__(self, in_columns: Optional[List[str]] = None, inplace: bool = True, standardize: bool = True):
+    def __init__(
+        self, in_column: Optional[Union[str, List[str]]] = None, inplace: bool = True, standardize: bool = True
+    ):
         self.standardize = standardize
         super().__init__(
-            in_columns=in_columns,
+            in_column=in_column,
             inplace=inplace,
             transformer=PowerTransformer(method="yeo-johnson", standardize=self.standardize),
         )
@@ -21,10 +24,12 @@ class YeoJohnsonTransform(SklearnTransform):
 class BoxCoxTransform(SklearnTransform):
     """BoxCoxTransform applies Box-Cox transformation to DataFrame."""
 
-    def __init__(self, in_columns: Optional[List[str]] = None, inplace: bool = True, standardize: bool = True):
+    def __init__(
+        self, in_column: Optional[Union[str, List[str]]] = None, inplace: bool = True, standardize: bool = True
+    ):
         self.standardize = standardize
         super().__init__(
-            in_columns=in_columns,
+            in_column=in_column,
             inplace=inplace,
             transformer=PowerTransformer(method="box-cox", standardize=self.standardize),
         )

--- a/etna/transforms/scalers.py
+++ b/etna/transforms/scalers.py
@@ -19,7 +19,7 @@ class StandardScalerTransform(SklearnTransform):
 
     def __init__(
         self,
-        in_columns: Optional[List[str]] = None,
+        in_column: Optional[Union[str, List[str]]] = None,
         inplace: bool = True,
         with_mean: bool = True,
         with_std: bool = True,
@@ -29,7 +29,7 @@ class StandardScalerTransform(SklearnTransform):
 
         Parameters
         ----------
-        in_columns:
+        in_column:
             columns to be scaled, if None - all columns will be scaled.
         inplace:
             features are changed by scaled.
@@ -40,7 +40,7 @@ class StandardScalerTransform(SklearnTransform):
         """
         super().__init__(
             transformer=StandardScaler(with_mean=with_mean, with_std=with_std, copy=True),
-            in_columns=in_columns,
+            in_column=in_column,
             inplace=inplace,
         )
         self.with_mean = with_mean
@@ -55,7 +55,7 @@ class RobustScalerTransform(SklearnTransform):
 
     def __init__(
         self,
-        in_columns: Optional[Union[str, List[str]]] = None,
+        in_column: Optional[Union[str, List[str]]] = None,
         inplace: bool = True,
         with_centering: bool = True,
         with_scaling: bool = True,
@@ -67,7 +67,7 @@ class RobustScalerTransform(SklearnTransform):
 
         Parameters
         ----------
-        in_columns:
+        in_column:
             columns to be scaled, if None - all columns will be scaled.
         inplace:
             features are changed by scaled.
@@ -84,7 +84,7 @@ class RobustScalerTransform(SklearnTransform):
             the dataset will be scaled up.
         """
         super().__init__(
-            in_columns=in_columns,
+            in_column=in_column,
             inplace=inplace,
             transformer=RobustScaler(
                 with_centering=with_centering,
@@ -108,7 +108,7 @@ class MinMaxScalerTransform(SklearnTransform):
 
     def __init__(
         self,
-        in_columns: Optional[List[str]] = None,
+        in_column: Optional[Union[str, List[str]]] = None,
         inplace: bool = True,
         feature_range: Tuple[float, float] = (0, 1),
         clip: bool = True,
@@ -118,7 +118,7 @@ class MinMaxScalerTransform(SklearnTransform):
 
         Parameters
         ----------
-        in_columns:
+        in_column:
             columns to be scaled, if None - all columns will be scaled.
         inplace:
             features are changed by scaled.
@@ -128,7 +128,7 @@ class MinMaxScalerTransform(SklearnTransform):
             set to True to clip transformed values of held-out data to provided feature range.
         """
         super().__init__(
-            in_columns=in_columns,
+            in_column=in_column,
             inplace=inplace,
             transformer=MinMaxScaler(feature_range=feature_range, clip=clip, copy=True),
         )
@@ -142,17 +142,17 @@ class MaxAbsScalerTransform(SklearnTransform):
     Uses sklearn.preprocessing.MaxAbsScaler inside.
     """
 
-    def __init__(self, in_columns: Optional[List[str]] = None, inplace: bool = True):
+    def __init__(self, in_column: Optional[Union[str, List[str]]] = None, inplace: bool = True):
         """Init MinMaxScalerPreprocess.
 
         Parameters
         ----------
-        in_columns:
+        in_column:
             columns to be scaled, if None - all columns will be scaled.
         inplace:
             features are changed by scaled.
         """
-        super().__init__(in_columns=in_columns, inplace=inplace, transformer=MaxAbsScaler(copy=True))
+        super().__init__(in_column=in_column, inplace=inplace, transformer=MaxAbsScaler(copy=True))
 
 
 __all__ = [

--- a/tests/test_transforms/test_power.py
+++ b/tests/test_transforms/test_power.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from sklearn.preprocessing import PowerTransformer
 
+from etna.datasets import TSDataset
 from etna.transforms.power import BoxCoxTransform
 from etna.transforms.power import YeoJohnsonTransform
 
@@ -14,18 +15,12 @@ from etna.transforms.power import YeoJohnsonTransform
 def non_positive_df() -> pd.DataFrame:
     df_1 = pd.DataFrame.from_dict({"timestamp": pd.date_range("2021-06-01", "2021-07-01", freq="1d")})
     df_2 = pd.DataFrame.from_dict({"timestamp": pd.date_range("2021-06-01", "2021-07-01", freq="1d")})
-    generator = np.random.RandomState(seed=1)
     df_1["segment"] = "Moscow"
-    df_1["target"] = -1
+    df_1["target"] = 0
     df_2["segment"] = "Omsk"
-    df_2["target"] = -100
+    df_2["target"] = -1
     classic_df = pd.concat([df_1, df_2], ignore_index=True)
-
-    df = classic_df.pivot(index="timestamp", columns="segment")
-    df = df.reorder_levels([1, 0], axis=1)
-    df = df.sort_index(axis=1)
-    df.columns.names = ["segment", "feature"]
-    return df
+    return TSDataset.to_dataset(classic_df)
 
 
 @pytest.fixture
@@ -38,16 +33,11 @@ def positive_df() -> pd.DataFrame:
     df_2["segment"] = "Omsk"
     df_2["target"] = generator.normal(loc=20, scale=1, size=len(df_1))
     classic_df = pd.concat([df_1, df_2], ignore_index=True)
-
-    df = classic_df.pivot(index="timestamp", columns="segment")
-    df = df.reorder_levels([1, 0], axis=1)
-    df = df.sort_index(axis=1)
-    df.columns.names = ["segment", "feature"]
-    return df
+    return TSDataset.to_dataset(classic_df)
 
 
-def test_negative_series_behavior(non_positive_df: pd.DataFrame):
-    """Check BoxCoxPreprocessing behavior in case of negative-value series"""
+def test_non_positive_series_behavior(non_positive_df: pd.DataFrame):
+    """Check BoxCoxPreprocessing behavior in case of negative-value series."""
     preprocess = BoxCoxTransform()
     with pytest.raises(ValueError):
         _ = preprocess.fit_transform(df=non_positive_df)
@@ -56,18 +46,45 @@ def test_negative_series_behavior(non_positive_df: pd.DataFrame):
 @pytest.mark.parametrize(
     "preprocessing_class,method", ((BoxCoxTransform, "box-cox"), (YeoJohnsonTransform, "yeo-johnson"))
 )
-def test_transform_value(positive_df: pd.DataFrame, preprocessing_class: Any, method: str):
-    """Check the value of transform result."""
-    preprocess = preprocessing_class()
-    value = preprocess.fit_transform(df=positive_df.copy())
+def test_transform_value_all_columns(positive_df: pd.DataFrame, preprocessing_class: Any, method: str):
+    """Check the value of transform result for all columns."""
+    preprocess_none = preprocessing_class()
+    preprocess_all = preprocessing_class(in_column=positive_df.columns.get_level_values("feature").unique())
+    value_none = preprocess_none.fit_transform(df=positive_df.copy())
+    value_all = preprocess_all.fit_transform(df=positive_df.copy())
     true_values = PowerTransformer(method=method).fit_transform(positive_df.values)
+    npt.assert_array_almost_equal(value_none.values, true_values)
+    npt.assert_array_almost_equal(value_all.values, true_values)
+
+
+@pytest.mark.parametrize(
+    "preprocessing_class,method", ((BoxCoxTransform, "box-cox"), (YeoJohnsonTransform, "yeo-johnson"))
+)
+def test_transform_value_one_column(positive_df: pd.DataFrame, preprocessing_class: Any, method: str):
+    """Check the value of transform result."""
+    preprocess = preprocessing_class(in_column="target")
+    value = preprocess.fit_transform(df=positive_df.copy())
+    true_values = PowerTransformer(method=method).fit_transform(positive_df.loc[:, pd.IndexSlice[:, "target"]].values)
     npt.assert_array_almost_equal(value.values, true_values)
 
 
 @pytest.mark.parametrize("preprocessing_class", (BoxCoxTransform, YeoJohnsonTransform))
-def test_inverse_transform(positive_df: pd.DataFrame, preprocessing_class: Any):
-    """Check that inverse_transform rolls back transform result."""
-    preprocess = preprocessing_class()
+def test_inverse_transform_all_columns(positive_df: pd.DataFrame, preprocessing_class: Any):
+    """Check that inverse_transform rolls back transform result for all columns."""
+    preprocess_none = preprocessing_class()
+    preprocess_all = preprocessing_class(in_column=positive_df.columns.get_level_values("feature").unique())
+    transformed_target_none = preprocess_none.fit_transform(df=positive_df.copy())
+    transformed_target_all = preprocess_all.fit_transform(df=positive_df.copy())
+    inversed_target_none = preprocess_none.inverse_transform(df=transformed_target_none)
+    inversed_target_all = preprocess_none.inverse_transform(df=transformed_target_all)
+    np.testing.assert_array_almost_equal(inversed_target_none.values, positive_df.values)
+    np.testing.assert_array_almost_equal(inversed_target_all.values, positive_df.values)
+
+
+@pytest.mark.parametrize("preprocessing_class", (BoxCoxTransform, YeoJohnsonTransform))
+def test_inverse_transform_one_column(positive_df: pd.DataFrame, preprocessing_class: Any):
+    """Check that inverse_transform rolls back transform result for one column."""
+    preprocess = preprocessing_class(in_column="target")
     transformed_target = preprocess.fit_transform(df=positive_df.copy())
     inversed_target = preprocess.inverse_transform(df=transformed_target)
     np.testing.assert_array_almost_equal(inversed_target.values, positive_df.values)


### PR DESCRIPTION
For `SklearnTransform` `in_columns` was replaced with `in_column`. Now we can use one column as a viable option.