### PR TITLE
Fixed warning problem in `AddConsntTransform` and `LogTransform`

### DIFF
--- a/etna/transforms/add_constant.py
+++ b/etna/transforms/add_constant.py
@@ -46,8 +46,9 @@ class _OneSegmentAddConstTransform(Transform):
         -------
         transformed series
         """
-        df[self.out_column] = df[self.in_column] + self.value
-        return df
+        result_df = df.copy()
+        result_df[self.out_column] = result_df[self.in_column] + self.value
+        return result_df
 
     def inverse_transform(self, df: pd.DataFrame) -> pd.DataFrame:
         """
@@ -62,9 +63,10 @@ class _OneSegmentAddConstTransform(Transform):
         -------
         transformed series
         """
+        result_df = df.copy()
         if self.inplace:
-            df[self.in_column] = df[self.out_column] - self.value
-        return df
+            result_df[self.in_column] = result_df[self.out_column] - self.value
+        return result_df
 
 
 class AddConstTransform(PerSegmentWrapper):

--- a/etna/transforms/log.py
+++ b/etna/transforms/log.py
@@ -58,9 +58,9 @@ class _OneSegmentLogTransform(Transform):
         """
         if (df[self.in_column] < 0).any():
             raise ValueError("LogPreprocess can be applied only to non-negative series")
-        df_result = df.copy()
-        df_result[self.out_column] = df_result[self.in_column].apply(lambda x: log(x + 1, self.base))
-        return df_result
+        result_df = df.copy()
+        result_df[self.out_column] = result_df[self.in_column].apply(lambda x: log(x + 1, self.base))
+        return result_df
 
     def inverse_transform(self, df: pd.DataFrame) -> pd.DataFrame:
         """

--- a/etna/transforms/log.py
+++ b/etna/transforms/log.py
@@ -58,8 +58,9 @@ class _OneSegmentLogTransform(Transform):
         """
         if (df[self.in_column] < 0).any():
             raise ValueError("LogPreprocess can be applied only to non-negative series")
-        df[self.out_column] = df[self.in_column].apply(lambda x: log(x + 1, self.base))
-        return df
+        df_result = df.copy()
+        df_result[self.out_column] = df_result[self.in_column].apply(lambda x: log(x + 1, self.base))
+        return df_result
 
     def inverse_transform(self, df: pd.DataFrame) -> pd.DataFrame:
         """
@@ -74,9 +75,10 @@ class _OneSegmentLogTransform(Transform):
         -------
         transformed series
         """
+        result_df = df.copy()
         if self.inplace:
-            df[self.in_column] = df[self.out_column].apply(lambda x: pow(self.base, x) - 1)
-        return df
+            result_df[self.in_column] = result_df[self.out_column].apply(lambda x: pow(self.base, x) - 1)
+        return result_df
 
 
 class LogTransform(PerSegmentWrapper):


### PR DESCRIPTION
There was a problem that `SetCopyWarning` was shown during applying `fit_tranform` and `inverse_transform` to `AddConsntTransform` and `LogTransform`. The problem was solved by adding copying of dataframe at the beginning of the methods (this copy is made in all other methods, that work with `PerSegmentWrapper` and don't have this issue).