### PR TITLE
ETNA-758: density anomalies threshold -> std

### DIFF
--- a/etna/analysis/outliers/density_outliers.py
+++ b/etna/analysis/outliers/density_outliers.py
@@ -66,14 +66,14 @@ def get_segment_density_outliers_indices(
 def get_anomalies_density(
     ts: TSDataset,
     window_size: int = 15,
-    distance_threshold: float = 100,
+    distance_coef: float = 3,
     n_neighbors: int = 3,
     distance_func: Callable[[float, float], float] = lambda x, y: abs(x - y),
 ) -> Dict[str, List[pd.Timestamp]]:
     """Compute outliers according to density rule.
 
     For each element in the series build all the windows of size window_size containing this point.
-    If any of the windows contains at least n_neighbors that are closer than distance_threshold
+    If any of the windows contains at least n_neighbors that are closer than distance_coef * std(series)
     to target point according to distance_func target point is not an outlier.
 
     Parameters
@@ -82,8 +82,8 @@ def get_anomalies_density(
         TSDataset with timeseries data
     window_size:
         size of windows to build
-    distance_threshold:
-        distance threshold to determine points are close to each other
+    distance_coef:
+        factor for standard deviation that forms distance threshold to determine points are close to each other
     n_neighbors:
         min number of close neighbors of point not to be outlier
     distance_func:
@@ -108,7 +108,7 @@ def get_anomalies_density(
         outliers_idxs = get_segment_density_outliers_indices(
             series=series,
             window_size=window_size,
-            distance_threshold=distance_threshold,
+            distance_threshold=distance_coef * np.std(series),
             n_neighbors=n_neighbors,
             distance_func=distance_func,
         )

--- a/etna/analysis/outliers/density_outliers.py
+++ b/etna/analysis/outliers/density_outliers.py
@@ -101,7 +101,8 @@ def get_anomalies_density(
     segments = ts.segments
     outliers_per_segment = {}
     for seg in segments:
-        # TODO: убрать dropna, когда TSDataset.slice не будет возвращать NaNs в начале ряда
+        # TODO: dropna() now is responsible for removing nan-s at the end of the sequence and in the middle of it
+        #   May be error or warning should be raised in this case
         segment_df = ts[:, seg, :][seg].dropna().reset_index()
         series = segment_df["target"].values
         timestamps = segment_df["timestamp"].values

--- a/tests/test_analysis/test_outliers/test_density_outliers.py
+++ b/tests/test_analysis/test_outliers/test_density_outliers.py
@@ -34,7 +34,7 @@ def test_get_segment_density_outliers_indices(
 
 
 def test_get_anomalies_density_interface(outliers_tsds: TSDataset):
-    outliers = get_anomalies_density(ts=outliers_tsds, window_size=7, distance_threshold=2, n_neighbors=3)
+    outliers = get_anomalies_density(ts=outliers_tsds, window_size=7, distance_coef=2, n_neighbors=3)
     for segment in ["1", "2"]:
         assert segment in outliers
         assert isinstance(outliers[segment], list)
@@ -42,7 +42,7 @@ def test_get_anomalies_density_interface(outliers_tsds: TSDataset):
 
 def test_get_anomalies_density(outliers_tsds: TSDataset):
     """Check if get_anomalies_density works correctly."""
-    outliers = get_anomalies_density(ts=outliers_tsds, window_size=7, distance_threshold=2.1, n_neighbors=3)
+    outliers = get_anomalies_density(ts=outliers_tsds, window_size=7, distance_coef=2.1, n_neighbors=3)
     expected = {"1": [np.datetime64("2021-01-11")], "2": [np.datetime64("2021-01-09"), np.datetime64("2021-01-27")]}
     for key in expected:
         assert key in outliers


### PR DESCRIPTION
Changed logic in `get_anomalies_density`: `distance_threshold` was replaced with `distance_coef`. Distance threshold is computed as ``distance_threshold * std(series)` to account for different scales of segments.