### PR TITLE
Fully parallel backtest

### DIFF
--- a/etna/model_selection/backtest.py
+++ b/etna/model_selection/backtest.py
@@ -129,9 +129,7 @@ class TimeSeriesCrossValidation(BaseMixin):
                     f"series {segment} does not."
                 )
 
-    def _generate_folds_dataframes(
-        self, ts: TSDataset
-    ) -> Tuple[TSDataset, TSDataset]:
+    def _generate_folds_dataframes(self, ts: TSDataset) -> Tuple[TSDataset, TSDataset]:
         """
         Generate a sequence of train-test pairs according to timestamp.
 
@@ -284,12 +282,8 @@ class TimeSeriesCrossValidation(BaseMixin):
         """
         self._validate_features(ts=ts)
         folds = Parallel(n_jobs=self.n_jobs, verbose=11)(
-            delayed(self._run_fold)(
-                train=train, test=test, fold_number=i, transforms=transforms
-            )
-            for i, (train, test) in enumerate(
-                self._generate_folds_dataframes(ts=ts)
-            )
+            delayed(self._run_fold)(train=train, test=test, fold_number=i, transforms=transforms)
+            for i, (train, test) in enumerate(self._generate_folds_dataframes(ts=ts))
         )
 
         for i, fold in folds:

--- a/etna/model_selection/backtest.py
+++ b/etna/model_selection/backtest.py
@@ -129,16 +129,20 @@ class TimeSeriesCrossValidation(BaseMixin):
                     f"series {segment} does not."
                 )
 
-    def _generate_folds_dataframes(
-        self, ts: TSDataset, transforms: List[Transform] = []
+    def _generate_fold_dataframes(
+        self, fold_number: int, ts: TSDataset, transforms: List[Transform] = []
     ) -> Tuple[TSDataset, TSDataset, TSDataset]:
         """
         Generate a sequence of train-test pairs according to timestamp.
 
         Parameters
         ----------
+        fold_number:
+            number of fold to generate
         ts:
             dataset to split
+        transforms:
+            list of transforms that should be applied to df in backtest pipeline
 
         Returns
         -------
@@ -146,24 +150,24 @@ class TimeSeriesCrossValidation(BaseMixin):
         """
         timestamps = ts.index
         min_timestamp_idx, max_timestamp_idx = 0, len(timestamps)
-        for offset in range(self.n_folds, 0, -1):
-            # if not self._constant_history_length, left border of train df is always equal to minimal timestamp value;
-            # it means that all the given data is used.
-            # if self._constant_history_length, left border of train df moves to one horizon steps on each split
-            min_train_idx = min_timestamp_idx + (self.n_folds - offset) * self.horizon * self._constant_history_length
-            max_train_idx = max_timestamp_idx - self.horizon * offset - 1
-            min_test_idx = max_train_idx + 1
-            max_test_idx = max_train_idx + self.horizon
+        offset = self.n_folds - fold_number
+        # if not self._constant_history_length, left border of train df is always equal to minimal timestamp value;
+        # it means that all the given data is used.
+        # if self._constant_history_length, left border of train df moves to one horizon steps on each split
+        min_train_idx = min_timestamp_idx + (self.n_folds - offset) * self.horizon * self._constant_history_length
+        max_train_idx = max_timestamp_idx - self.horizon * offset - 1
+        min_test_idx = max_train_idx + 1
+        max_test_idx = max_train_idx + self.horizon
 
-            min_train, max_train = timestamps[min_train_idx], timestamps[max_train_idx]
-            min_test, max_test = timestamps[min_test_idx], timestamps[max_test_idx]
+        min_train, max_train = timestamps[min_train_idx], timestamps[max_train_idx]
+        min_test, max_test = timestamps[min_test_idx], timestamps[max_test_idx]
 
-            train, test = ts.train_test_split(
-                train_start=min_train, train_end=max_train, test_start=min_test, test_end=max_test
-            )
-            train.fit_transform(transforms=deepcopy(transforms))
-            forecast_base = train.make_future(future_steps=self.horizon)
-            yield train, test, forecast_base
+        train, test = ts.train_test_split(
+            train_start=min_train, train_end=max_train, test_start=min_test, test_end=max_test
+        )
+        train.fit_transform(transforms=deepcopy(transforms))
+        forecast_base = train.make_future(future_steps=self.horizon)
+        return train, test, forecast_base
 
     def _compute_metrics(self, y_true: TSDataset, y_pred: TSDataset) -> Dict[str, float]:
         """
@@ -265,6 +269,15 @@ class TimeSeriesCrossValidation(BaseMixin):
 
         return fold_number, fold
 
+    def _joblib_delayed_step(
+        self, fold_number: int, ts: TSDataset, transforms: List[Transform] = []
+    ) -> Tuple[int, Dict[int, Any]]:
+        """Connect generating data for split and running backtest for it."""
+        train, test, forecast_base = self._generate_fold_dataframes(
+            fold_number=fold_number, ts=ts, transforms=transforms
+        )
+        return self._run_fold(train=train, test=test, forecast_base=forecast_base, fold_number=fold_number)
+
     def backtest(
         self, ts: TSDataset, transforms: List[Transform] = ()
     ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
@@ -283,10 +296,8 @@ class TimeSeriesCrossValidation(BaseMixin):
         """
         self._validate_features(ts=ts)
         folds = Parallel(n_jobs=self.n_jobs, verbose=11)(
-            delayed(self._run_fold)(train=train, test=test, forecast_base=forecast_base, fold_number=i)
-            for i, (train, test, forecast_base) in enumerate(
-                self._generate_folds_dataframes(ts=ts, transforms=transforms)
-            )
+            delayed(self._joblib_delayed_step)(fold_number=fold_number, ts=ts, transforms=transforms)
+            for fold_number in range(self.n_folds)
         )
 
         for i, fold in folds:

--- a/etna/model_selection/backtest.py
+++ b/etna/model_selection/backtest.py
@@ -284,8 +284,7 @@ class TimeSeriesCrossValidation(BaseMixin):
             for train, test in self._generate_folds_dataframes(ts=ts)
         )
 
-        for i, fold in enumerate(folds):
-            self._folds[i] = fold
+        self._folds = {i: fold for i, fold in enumerate(folds)}
 
         metrics_df = self.get_metrics()
         forecast_df = self.get_forecasts()

--- a/tests/test_model_selection/test_backtest.py
+++ b/tests/test_model_selection/test_backtest.py
@@ -159,7 +159,8 @@ def test_generate_expandable_timeranges_days():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.expand.value
     )
-    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
+    for i in range(tscv.n_folds):
+        stage_dfs = tscv._generate_fold_dataframes(i, df)
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d").date()
@@ -182,7 +183,8 @@ def test_generate_expandable_timerange_hours():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.expand.value
     )
-    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
+    for i in range(tscv.n_folds):
+        stage_dfs = tscv._generate_fold_dataframes(i, df)
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d %H:%M:%S").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d %H:%M:%S").date()
@@ -205,7 +207,8 @@ def test_generate_constant_timeranges_days():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.constant.value
     )
-    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
+    for i in range(tscv.n_folds):
+        stage_dfs = tscv._generate_fold_dataframes(i, df)
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d").date()
@@ -227,7 +230,8 @@ def test_generate_constant_timeranges_hours():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.constant.value
     )
-    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
+    for i in range(tscv.n_folds):
+        stage_dfs = tscv._generate_fold_dataframes(i, df)
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d %H:%M:%S").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d %H:%M:%S").date()

--- a/tests/test_model_selection/test_backtest.py
+++ b/tests/test_model_selection/test_backtest.py
@@ -159,8 +159,7 @@ def test_generate_expandable_timeranges_days():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.expand.value
     )
-    for i in range(tscv.n_folds):
-        stage_dfs = tscv._generate_fold_dataframes(i, df)
+    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d").date()
@@ -183,8 +182,7 @@ def test_generate_expandable_timerange_hours():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.expand.value
     )
-    for i in range(tscv.n_folds):
-        stage_dfs = tscv._generate_fold_dataframes(i, df)
+    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d %H:%M:%S").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d %H:%M:%S").date()
@@ -207,8 +205,7 @@ def test_generate_constant_timeranges_days():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.constant.value
     )
-    for i in range(tscv.n_folds):
-        stage_dfs = tscv._generate_fold_dataframes(i, df)
+    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d").date()
@@ -230,8 +227,7 @@ def test_generate_constant_timeranges_hours():
     tscv = TimeSeriesCrossValidation(
         model=ProphetModel(), horizon=12, n_folds=3, metrics=DEFAULT_METRICS, mode=CrossValidationMode.constant.value
     )
-    for i in range(tscv.n_folds):
-        stage_dfs = tscv._generate_fold_dataframes(i, df)
+    for i, stage_dfs in enumerate(tscv._generate_folds_dataframes(df)):
         for stage_df, borders in zip(stage_dfs, true_borders[i]):
             assert stage_df.index.min() == datetime.strptime(borders[0], "%Y-%m-%d %H:%M:%S").date()
             assert stage_df.index.max() == datetime.strptime(borders[1], "%Y-%m-%d %H:%M:%S").date()


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (checklist)

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [x] Did you check the code style? `make lint` (`poetry install -E style`).
- [x] Did you make sure to update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you check that your code passes the unit tests `pytest tests/` ? 
- [ ] Did you add your new functionality to the docs?
- [ ] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

Rewrite calling `joblib.Parallel` inside `TimeSeriesCrossValidation.backtest` in a way that `TimeSeriesCrossValidation._generate_folds_dataframes` will be inside `joblib.delayed`.


## Related Issue

#56.


## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

<!-- Thank you for your contribution! -->

## Closing issues

Closes #56.
