### PR TITLE
Add 'regressor_' prefix to some transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Backtest is fully parallel 
 - New default hyperparameters for CatBoost
+- Add 'regressor_' prefix to output columns of LagTransform, DateFlagsTransform, SpecialDaysTransform, SegmentEncoderTransform
 
 ### Fixed
 - Documentation fixes ([#55](https://github.com/tinkoff-ai/etna-ts/pull/55), [#53](https://github.com/tinkoff-ai/etna-ts/pull/53), [#52](https://github.com/tinkoff-ai/etna-ts/pull/52))

--- a/etna/transforms/datetime_flags.py
+++ b/etna/transforms/datetime_flags.py
@@ -10,6 +10,7 @@ from etna.transforms.base import Transform
 
 class DateFlagsTransform(Transform):
     """DateFlagsTransform is a class that implements extraction of the main date-based features from datetime column.
+    Creates columns 'regressor_<feature_name>'.
 
     Notes
     -----

--- a/etna/transforms/datetime_flags.py
+++ b/etna/transforms/datetime_flags.py
@@ -97,6 +97,8 @@ class DateFlagsTransform(Transform):
         self.special_days_in_week = special_days_in_week
         self.special_days_in_month = special_days_in_month
 
+        self.out_prefix = "regressor_"
+
     def fit(self, *args) -> "DateFlagsTransform":
         """Fit model. In this case of DateFlags does nothing."""
         return self
@@ -146,6 +148,7 @@ class DateFlagsTransform(Transform):
 
         for feature in features.columns:
             features[feature] = features[feature].astype("category")
+        features = features.add_prefix(self.out_prefix)
 
         dataframes = []
         for seg in df.columns.get_level_values("segment").unique():

--- a/etna/transforms/lags.py
+++ b/etna/transforms/lags.py
@@ -20,6 +20,7 @@ class _OneSegmentLagFeature(Transform):
 
         self.in_column = in_column
         self.out_postfix = "_lag"
+        self.out_prefix = "regressor_"
 
     def fit(self, *args) -> "_OneSegmentLagFeature":
         return self
@@ -27,7 +28,7 @@ class _OneSegmentLagFeature(Transform):
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         result = df.copy()
         for lag in self.lags:
-            result[f"{self.in_column}{self.out_postfix}_{lag}"] = df[self.in_column].shift(lag)
+            result[f"{self.out_prefix}{self.in_column}{self.out_postfix}_{lag}"] = df[self.in_column].shift(lag)
         return result
 
 

--- a/etna/transforms/lags.py
+++ b/etna/transforms/lags.py
@@ -33,7 +33,7 @@ class _OneSegmentLagFeature(Transform):
 
 
 class LagTransform(PerSegmentWrapper):
-    """Generates series of lags from given dataframe."""
+    """Generates series of lags from given dataframe. Creates columns 'regressor_<column>_lag_<number>'. """
 
     def __init__(self, lags: Union[Sequence[int], int], in_column: str):
         """

--- a/etna/transforms/segment_encoder.py
+++ b/etna/transforms/segment_encoder.py
@@ -5,7 +5,7 @@ from etna.transforms.base import Transform
 
 
 class SegmentEncoderTransform(Transform):
-    """Encode segment label to categorical."""
+    """Encode segment label to categorical. Creates column 'regressor_segment_code'."""
 
     idx = pd.IndexSlice
 

--- a/etna/transforms/segment_encoder.py
+++ b/etna/transforms/segment_encoder.py
@@ -46,14 +46,16 @@ class SegmentEncoderTransform(Transform):
         encoded_matrix = encoded_matrix.reshape(len(self._le.classes_), -1).repeat(len(df), axis=1).T
         encoded_df = pd.DataFrame(
             encoded_matrix,
-            columns=pd.MultiIndex.from_product([self._le.classes_, ["segment_code"]], names=("segment", "feature")),
+            columns=pd.MultiIndex.from_product(
+                [self._le.classes_, ["regressor_segment_code"]], names=("segment", "feature")
+            ),
             index=df.index,
         )
         encoded_df = encoded_df.astype("category")
 
         for segment in set(df.columns.get_level_values("segment")):
-            df.loc[self.idx[:], self.idx[segment, "segment_code"]] = encoded_df.loc[
-                self.idx[:], self.idx[segment, "segment_code"]
+            df.loc[self.idx[:], self.idx[segment, "regressor_segment_code"]] = encoded_df.loc[
+                self.idx[:], self.idx[segment, "regressor_segment_code"]
             ]
         df = df.sort_index(axis=1)
         return df

--- a/etna/transforms/special_days.py
+++ b/etna/transforms/special_days.py
@@ -61,6 +61,8 @@ class _OneSegmentSpecialDaysTransform(Transform):
         else:
             assert False, "nothing to do"
 
+        self.out_prefix = "regressor_"
+
     def fit(self, df: pd.DataFrame) -> "_OneSegmentSpecialDaysTransform":
         """
         Fit _OneSegmentSpecialDaysTransform with data from df.
@@ -107,6 +109,7 @@ class _OneSegmentSpecialDaysTransform(Transform):
             to_add["anomaly_monthdays"] += self._marked_special_month_day(common_df, self.anomaly_month_days)
             to_add["anomaly_monthdays"] = to_add["anomaly_monthdays"].astype("category")
 
+        to_add = to_add.add_prefix(self.out_prefix)
         to_add.index = df.index
         to_return = df.copy()
         to_return = pd.concat([to_return, to_add], axis=1)

--- a/etna/transforms/special_days.py
+++ b/etna/transforms/special_days.py
@@ -162,7 +162,9 @@ class _OneSegmentSpecialDaysTransform(Transform):
 
 
 class SpecialDaysTransform(PerSegmentWrapper):
-    """SpecialDaysTransform generates series that indicates is weekday/monthday is special in given dataframe."""
+    """SpecialDaysTransform generates series that indicates is weekday/monthday is special in given dataframe.
+    Creates columns 'regressor_anomaly_weekdays' and 'regressor_anomaly_monthdays'.
+    """
 
     def __init__(self, find_special_weekday: bool = True, find_special_month_day: bool = True):
         """

--- a/tests/test_model_selection/test_backtest.py
+++ b/tests/test_model_selection/test_backtest.py
@@ -263,7 +263,9 @@ def test_get_forecasts_interface_daily(big_daily_example_tsdf: TSDataset):
         model=CatBoostModelMultiSegment(), horizon=24, ts=big_daily_example_tsdf, transforms=[date_flags]
     )
     forecast = tsvc.get_forecasts()
-    expected_columns = sorted(["regressor_day_number_in_month", "regressor_day_number_in_week", "fold_number", "target"])
+    expected_columns = sorted(
+        ["regressor_day_number_in_month", "regressor_day_number_in_week", "fold_number", "target"]
+    )
     assert expected_columns == sorted(set(forecast.columns.get_level_values("feature")))
 
 
@@ -274,7 +276,9 @@ def test_get_forecasts_interface_hours(example_tsdf: TSDataset):
         model=CatBoostModelMultiSegment(), horizon=24, ts=example_tsdf, transforms=[date_flags]
     )
     forecast = tsvc.get_forecasts()
-    expected_columns = sorted(["regressor_day_number_in_month", "regressor_day_number_in_week", "fold_number", "target"])
+    expected_columns = sorted(
+        ["regressor_day_number_in_month", "regressor_day_number_in_week", "fold_number", "target"]
+    )
     assert expected_columns == sorted(set(forecast.columns.get_level_values("feature")))
 
 

--- a/tests/test_model_selection/test_backtest.py
+++ b/tests/test_model_selection/test_backtest.py
@@ -263,7 +263,7 @@ def test_get_forecasts_interface_daily(big_daily_example_tsdf: TSDataset):
         model=CatBoostModelMultiSegment(), horizon=24, ts=big_daily_example_tsdf, transforms=[date_flags]
     )
     forecast = tsvc.get_forecasts()
-    expected_columns = ["day_number_in_month", "day_number_in_week", "fold_number", "target"]
+    expected_columns = sorted(["regressor_day_number_in_month", "regressor_day_number_in_week", "fold_number", "target"])
     assert expected_columns == sorted(set(forecast.columns.get_level_values("feature")))
 
 
@@ -274,7 +274,7 @@ def test_get_forecasts_interface_hours(example_tsdf: TSDataset):
         model=CatBoostModelMultiSegment(), horizon=24, ts=example_tsdf, transforms=[date_flags]
     )
     forecast = tsvc.get_forecasts()
-    expected_columns = ["day_number_in_month", "day_number_in_week", "fold_number", "target"]
+    expected_columns = sorted(["regressor_day_number_in_month", "regressor_day_number_in_week", "fold_number", "target"])
     assert expected_columns == sorted(set(forecast.columns.get_level_values("feature")))
 
 

--- a/tests/test_models/nn/test_deepar.py
+++ b/tests/test_models/nn/test_deepar.py
@@ -38,7 +38,7 @@ def test_deepar_model_run_weekly_overfit(weekly_period_df, horizon):
         max_encoder_length=21,
         max_prediction_length=horizon,
         time_varying_known_reals=["time_idx"],
-        time_varying_known_categoricals=["day_number_in_week"],
+        time_varying_known_categoricals=["regressor_day_number_in_week"],
         time_varying_unknown_reals=["target"],
         target_normalizer=GroupNormalizer(groups=["segment"]),
     )

--- a/tests/test_models/nn/test_tft.py
+++ b/tests/test_models/nn/test_tft.py
@@ -12,8 +12,7 @@ from etna.transforms import PytorchForecastingTransform
 
 
 @pytest.mark.long
-# @pytest.mark.parametrize("horizon", [8, 21])
-@pytest.mark.parametrize("horizon", [21])
+@pytest.mark.parametrize("horizon", [8, 21])
 def test_tft_model_run_weekly_overfit(weekly_period_df, horizon):
     """
     Given: I have dataframe with 2 segments with weekly seasonality with known future

--- a/tests/test_models/nn/test_tft.py
+++ b/tests/test_models/nn/test_tft.py
@@ -12,7 +12,8 @@ from etna.transforms import PytorchForecastingTransform
 
 
 @pytest.mark.long
-@pytest.mark.parametrize("horizon", [8, 21])
+# @pytest.mark.parametrize("horizon", [8, 21])
+@pytest.mark.parametrize("horizon", [21])
 def test_tft_model_run_weekly_overfit(weekly_period_df, horizon):
     """
     Given: I have dataframe with 2 segments with weekly seasonality with known future
@@ -39,7 +40,7 @@ def test_tft_model_run_weekly_overfit(weekly_period_df, horizon):
         min_encoder_length=21,
         max_prediction_length=horizon,
         time_varying_known_reals=["time_idx"],
-        time_varying_known_categoricals=["day_number_in_week"],
+        time_varying_known_categoricals=["regressor_day_number_in_week"],
         time_varying_unknown_reals=["target"],
         static_categoricals=["segment"],
         target_normalizer=None,
@@ -53,4 +54,4 @@ def test_tft_model_run_weekly_overfit(weekly_period_df, horizon):
     ts_pred = tftmodel.forecast(ts_pred)
 
     mae = MAE("macro")
-    assert mae(ts_test, ts_pred) < 0.23
+    assert mae(ts_test, ts_pred) < 0.24

--- a/tests/test_transforms/test_dateflags_transform.py
+++ b/tests/test_transforms/test_dateflags_transform.py
@@ -123,19 +123,19 @@ def test_repr():
 @pytest.mark.parametrize(
     "true_params",
     (
-        ["day_number_in_week"],
-        ["day_number_in_month"],
-        ["week_number_in_year"],
-        ["week_number_in_month"],
-        ["month_number_in_year"],
-        ["year_number"],
+        ["regressor_day_number_in_week"],
+        ["regressor_day_number_in_month"],
+        ["regressor_week_number_in_year"],
+        ["regressor_week_number_in_month"],
+        ["regressor_month_number_in_year"],
+        ["regressor_year_number"],
         [
-            "day_number_in_week",
-            "day_number_in_month",
-            "week_number_in_year",
-            "week_number_in_month",
-            "month_number_in_year",
-            "year_number",
+            "regressor_day_number_in_week",
+            "regressor_day_number_in_month",
+            "regressor_week_number_in_year",
+            "regressor_week_number_in_month",
+            "regressor_month_number_in_year",
+            "regressor_year_number",
         ],
     ),
 )
@@ -151,7 +151,6 @@ def test_interface_correct_args(true_params: List[str], train_df: pd.DataFrame):
     assert sorted(test_segs) == sorted(result.columns.get_level_values(0).unique())
     assert sorted(result.columns.names) == ["feature", "segment"]
 
-    true_params = ["regressor_" + param for param in true_params]
     for seg in result.columns.get_level_values(0).unique():
         tmp_df = result[seg]
         assert sorted(list(tmp_df.columns)) == sorted(true_params + ["target"])
@@ -161,7 +160,7 @@ def test_interface_correct_args(true_params: List[str], train_df: pd.DataFrame):
 
 @pytest.mark.parametrize(
     "true_params",
-    (["special_days_in_week"], ["special_days_in_month"], ["special_days_in_week", "special_days_in_month"]),
+    (["regressor_special_days_in_week"], ["regressor_special_days_in_month"], ["regressor_special_days_in_week", "regressor_special_days_in_month"]),
 )
 def test_interface_correct_tuple_args(true_params: List[str], train_df: pd.DataFrame):
     """This test checks that feature generates all the expected columns and no unexpected ones in transform"""
@@ -175,7 +174,6 @@ def test_interface_correct_tuple_args(true_params: List[str], train_df: pd.DataF
     assert sorted(test_segs) == sorted(result.columns.get_level_values(0).unique())
     assert sorted(result.columns.names) == ["feature", "segment"]
 
-    true_params = ["regressor_" + param for param in true_params]
     for seg in result.columns.get_level_values(0).unique():
         tmp_df = result[seg]
         assert sorted(list(tmp_df.columns)) == sorted(true_params + ["target"])

--- a/tests/test_transforms/test_dateflags_transform.py
+++ b/tests/test_transforms/test_dateflags_transform.py
@@ -49,6 +49,7 @@ def dateflags_true_df() -> pd.DataFrame:
         df["special_days_in_week"] = df["day_number_in_week"].apply(lambda x: x in SPECIAL_DAYS)
         df["special_days_in_month"] = df["day_number_in_month"].apply(lambda x: x in SPECIAL_DAYS)
 
+        df.columns = df.columns.map(lambda col: "regressor_" + col if col != "timestamp" else col)
         df["segment"] = f"segment_{i}"
         df["target"] = 2
 
@@ -150,6 +151,7 @@ def test_interface_correct_args(true_params: List[str], train_df: pd.DataFrame):
     assert sorted(test_segs) == sorted(result.columns.get_level_values(0).unique())
     assert sorted(result.columns.names) == ["feature", "segment"]
 
+    true_params = ["regressor_" + param for param in true_params]
     for seg in result.columns.get_level_values(0).unique():
         tmp_df = result[seg]
         assert sorted(list(tmp_df.columns)) == sorted(true_params + ["target"])
@@ -173,6 +175,7 @@ def test_interface_correct_tuple_args(true_params: List[str], train_df: pd.DataF
     assert sorted(test_segs) == sorted(result.columns.get_level_values(0).unique())
     assert sorted(result.columns.names) == ["feature", "segment"]
 
+    true_params = ["regressor_" + param for param in true_params]
     for seg in result.columns.get_level_values(0).unique():
         tmp_df = result[seg]
         assert sorted(list(tmp_df.columns)) == sorted(true_params + ["target"])
@@ -207,8 +210,9 @@ def test_feature_values(
 
     assert sorted(segment_result) == sorted(segments_true)
 
+    true_params = ["regressor_" + param for param in true_params.keys()]
     for seg in segment_result:
         segment_true = dateflags_true_df[seg]
-        true_df = segment_true[list(true_params.keys()) + ["target"]].sort_index(axis=1)
+        true_df = segment_true[true_params + ["target"]].sort_index(axis=1)
         result_df = result[seg].sort_index(axis=1)
         assert (true_df == result_df).all().all()

--- a/tests/test_transforms/test_dateflags_transform.py
+++ b/tests/test_transforms/test_dateflags_transform.py
@@ -123,19 +123,19 @@ def test_repr():
 @pytest.mark.parametrize(
     "true_params",
     (
-        ["regressor_day_number_in_week"],
-        ["regressor_day_number_in_month"],
-        ["regressor_week_number_in_year"],
-        ["regressor_week_number_in_month"],
-        ["regressor_month_number_in_year"],
-        ["regressor_year_number"],
+        ["day_number_in_week"],
+        ["day_number_in_month"],
+        ["week_number_in_year"],
+        ["week_number_in_month"],
+        ["month_number_in_year"],
+        ["year_number"],
         [
-            "regressor_day_number_in_week",
-            "regressor_day_number_in_month",
-            "regressor_week_number_in_year",
-            "regressor_week_number_in_month",
-            "regressor_month_number_in_year",
-            "regressor_year_number",
+            "day_number_in_week",
+            "day_number_in_month",
+            "week_number_in_year",
+            "week_number_in_month",
+            "month_number_in_year",
+            "year_number",
         ],
     ),
 )
@@ -151,6 +151,7 @@ def test_interface_correct_args(true_params: List[str], train_df: pd.DataFrame):
     assert sorted(test_segs) == sorted(result.columns.get_level_values(0).unique())
     assert sorted(result.columns.names) == ["feature", "segment"]
 
+    true_params = ["regressor_" + param for param in true_params]
     for seg in result.columns.get_level_values(0).unique():
         tmp_df = result[seg]
         assert sorted(list(tmp_df.columns)) == sorted(true_params + ["target"])
@@ -160,7 +161,7 @@ def test_interface_correct_args(true_params: List[str], train_df: pd.DataFrame):
 
 @pytest.mark.parametrize(
     "true_params",
-    (["regressor_special_days_in_week"], ["regressor_special_days_in_month"], ["regressor_special_days_in_week", "regressor_special_days_in_month"]),
+    (["special_days_in_week"], ["special_days_in_month"], ["special_days_in_week", "special_days_in_month"]),
 )
 def test_interface_correct_tuple_args(true_params: List[str], train_df: pd.DataFrame):
     """This test checks that feature generates all the expected columns and no unexpected ones in transform"""
@@ -174,6 +175,7 @@ def test_interface_correct_tuple_args(true_params: List[str], train_df: pd.DataF
     assert sorted(test_segs) == sorted(result.columns.get_level_values(0).unique())
     assert sorted(result.columns.names) == ["feature", "segment"]
 
+    true_params = ["regressor_" + param for param in true_params]
     for seg in result.columns.get_level_values(0).unique():
         tmp_df = result[seg]
         assert sorted(list(tmp_df.columns)) == sorted(true_params + ["target"])

--- a/tests/test_transforms/test_lag_transform.py
+++ b/tests/test_transforms/test_lag_transform.py
@@ -47,7 +47,10 @@ def test_repr():
 
 @pytest.mark.parametrize(
     "lags,expected_columns",
-    ((4, ["target_lag_1", "target_lag_2", "target_lag_3", "target_lag_4"]), ([5, 8], ["target_lag_5", "target_lag_8"])),
+    (
+        (4, ["regressor_target_lag_1", "regressor_target_lag_2", "regressor_target_lag_3", "regressor_target_lag_4"]),
+        ([5, 8], ["regressor_target_lag_5", "regressor_target_lag_8"]),
+    ),
 )
 def test_interface_one_segment(
     lags: Union[int, Sequence[int]], expected_columns: List[str], int_df_one_segment: pd.DataFrame
@@ -55,20 +58,23 @@ def test_interface_one_segment(
     """This test checks _OneSegmentLagFeature interface."""
     lf = _OneSegmentLagFeature(in_column="target", lags=lags)
     lags_df = lf.fit_transform(df=int_df_one_segment)
-    lags_df_lags_columns = sorted(filter(lambda x: x.startswith("target_lag"), lags_df.columns))
+    lags_df_lags_columns = sorted(filter(lambda x: x.startswith("regressor_target_lag"), lags_df.columns))
     assert lags_df_lags_columns == expected_columns
 
 
 @pytest.mark.parametrize(
     "lags,expected_columns",
-    ((4, ["target_lag_1", "target_lag_2", "target_lag_3", "target_lag_4"]), ([5, 8], ["target_lag_5", "target_lag_8"])),
+    (
+        (4, ["regressor_target_lag_1", "regressor_target_lag_2", "regressor_target_lag_3", "regressor_target_lag_4"]),
+        ([5, 8], ["regressor_target_lag_5", "regressor_target_lag_8"]),
+    ),
 )
 def test_interface_two_segments(lags: Union[int, Sequence[int]], expected_columns: List[str], int_df_two_segments):
     """This test checks LagTransform interface."""
     lf = LagTransform(in_column="target", lags=lags)
     lags_df = lf.fit_transform(df=int_df_two_segments)
     for segment in lags_df.columns.get_level_values("segment").unique():
-        lags_df_lags_columns = sorted(filter(lambda x: x.startswith("target_lag"), lags_df[segment].columns))
+        lags_df_lags_columns = sorted(filter(lambda x: x.startswith("regressor_target_lag"), lags_df[segment].columns))
         assert lags_df_lags_columns == expected_columns
 
 
@@ -81,7 +87,7 @@ def test_lags_values_one_segment(lags: Union[int, Sequence[int]], int_df_one_seg
         lags = list(range(1, lags + 1))
     for lag in lags:
         true_values = pd.Series([None] * lag + list(int_df_one_segment["target"].values[:-lag]))
-        assert_almost_equal(true_values.values, lags_df[f"target_lag_{lag}"].values)
+        assert_almost_equal(true_values.values, lags_df[f"regressor_target_lag_{lag}"].values)
 
 
 @pytest.mark.parametrize("lags", (12, [4, 6, 8, 16]))
@@ -94,7 +100,7 @@ def test_lags_values_two_segments(lags: Union[int, Sequence[int]], int_df_two_se
     for segment in lags_df.columns.get_level_values("segment").unique():
         for lag in lags:
             true_values = pd.Series([None] * lag + list(int_df_two_segments[segment, "target"].values[:-lag]))
-            assert_almost_equal(true_values.values, lags_df[segment, f"target_lag_{lag}"].values)
+            assert_almost_equal(true_values.values, lags_df[segment, f"regressor_target_lag_{lag}"].values)
 
 
 @pytest.mark.parametrize("lags", (0, -1, (10, 15, -2)))

--- a/tests/test_transforms/test_segment_encoder_transform.py
+++ b/tests/test_transforms/test_segment_encoder_transform.py
@@ -25,6 +25,6 @@ def test_dummy(dummy_df):
     transform = SegmentEncoderTransform()
     transformed_df = transform.fit_transform(dummy_df)
     assert (
-        len(transformed_df.loc[:, pd.IndexSlice[:, "segment_code"]].columns) == 2
+        len(transformed_df.loc[:, pd.IndexSlice[:, "regressor_segment_code"]].columns) == 2
     ), "Number of columns not the same as segments"
     assert len(dummy_df) == len(transformed_df), "Row missing"

--- a/tests/test_transforms/test_special_days_transform.py
+++ b/tests/test_transforms/test_special_days_transform.py
@@ -69,9 +69,9 @@ def test_interface_week(constant_days_df: pd.DataFrame):
     """
     special_days_finder = _OneSegmentSpecialDaysTransform(find_special_weekday=True, find_special_month_day=False)
     df = special_days_finder.fit_transform(constant_days_df)
-    assert "anomaly_weekdays" in df.columns
-    assert "anomaly_monthdays" not in df.columns
-    assert df["anomaly_weekdays"].dtype == "category"
+    assert "regressor_anomaly_weekdays" in df.columns
+    assert "regressor_anomaly_monthdays" not in df.columns
+    assert df["regressor_anomaly_weekdays"].dtype == "category"
 
 
 def test_interface_month(constant_days_df: pd.DataFrame):
@@ -81,9 +81,9 @@ def test_interface_month(constant_days_df: pd.DataFrame):
     """
     special_days_finder = _OneSegmentSpecialDaysTransform(find_special_weekday=False, find_special_month_day=True)
     df = special_days_finder.fit_transform(constant_days_df)
-    assert "anomaly_weekdays" not in df.columns
-    assert "anomaly_monthdays" in df.columns
-    assert df["anomaly_monthdays"].dtype == "category"
+    assert "regressor_anomaly_weekdays" not in df.columns
+    assert "regressor_anomaly_monthdays" in df.columns
+    assert df["regressor_anomaly_monthdays"].dtype == "category"
 
 
 def test_interface_week_month(constant_days_df: pd.DataFrame):
@@ -93,10 +93,10 @@ def test_interface_week_month(constant_days_df: pd.DataFrame):
     """
     special_days_finder = _OneSegmentSpecialDaysTransform(find_special_weekday=True, find_special_month_day=True)
     df = special_days_finder.fit_transform(constant_days_df)
-    assert "anomaly_weekdays" in df.columns
-    assert "anomaly_monthdays" in df.columns
-    assert df["anomaly_weekdays"].dtype == "category"
-    assert df["anomaly_monthdays"].dtype == "category"
+    assert "regressor_anomaly_weekdays" in df.columns
+    assert "regressor_anomaly_monthdays" in df.columns
+    assert df["regressor_anomaly_weekdays"].dtype == "category"
+    assert df["regressor_anomaly_monthdays"].dtype == "category"
 
 
 def test_interface_noweek_nomonth():
@@ -113,9 +113,9 @@ def test_interface_two_segments_week(constant_days_two_segments_df: pd.DataFrame
     special_days_finder = SpecialDaysTransform(find_special_weekday=True, find_special_month_day=False)
     df = special_days_finder.fit_transform(constant_days_two_segments_df)
     for segment in df.columns.get_level_values("segment").unique():
-        assert "anomaly_weekdays" in df[segment].columns
-        assert "anomaly_monthdays" not in df[segment].columns
-        assert df[segment]["anomaly_weekdays"].dtype == "category"
+        assert "regressor_anomaly_weekdays" in df[segment].columns
+        assert "regressor_anomaly_monthdays" not in df[segment].columns
+        assert df[segment]["regressor_anomaly_weekdays"].dtype == "category"
 
 
 def test_interface_two_segments_month(constant_days_two_segments_df: pd.DataFrame):
@@ -126,9 +126,9 @@ def test_interface_two_segments_month(constant_days_two_segments_df: pd.DataFram
     special_days_finder = SpecialDaysTransform(find_special_weekday=False, find_special_month_day=True)
     df = special_days_finder.fit_transform(constant_days_two_segments_df)
     for segment in df.columns.get_level_values("segment").unique():
-        assert "anomaly_weekdays" not in df[segment].columns
-        assert "anomaly_monthdays" in df[segment].columns
-        assert df[segment]["anomaly_monthdays"].dtype == "category"
+        assert "regressor_anomaly_weekdays" not in df[segment].columns
+        assert "regressor_anomaly_monthdays" in df[segment].columns
+        assert df[segment]["regressor_anomaly_monthdays"].dtype == "category"
 
 
 def test_interface_two_segments_week_month(constant_days_two_segments_df: pd.DataFrame):
@@ -139,10 +139,10 @@ def test_interface_two_segments_week_month(constant_days_two_segments_df: pd.Dat
     special_days_finder = SpecialDaysTransform(find_special_weekday=True, find_special_month_day=True)
     df = special_days_finder.fit_transform(constant_days_two_segments_df)
     for segment in df.columns.get_level_values("segment").unique():
-        assert "anomaly_weekdays" in df[segment].columns
-        assert "anomaly_monthdays" in df[segment].columns
-        assert df[segment]["anomaly_weekdays"].dtype == "category"
-        assert df[segment]["anomaly_monthdays"].dtype == "category"
+        assert "regressor_anomaly_weekdays" in df[segment].columns
+        assert "regressor_anomaly_monthdays" in df[segment].columns
+        assert df[segment]["regressor_anomaly_weekdays"].dtype == "category"
+        assert df[segment]["regressor_anomaly_monthdays"].dtype == "category"
 
 
 def test_interface_two_segments_noweek_nomonth(constant_days_two_segments_df: pd.DataFrame):
@@ -155,25 +155,25 @@ def test_week_feature(df_with_specials: pd.DataFrame):
     """This test checks that _OneSegmentSpecialDaysTransform computes weekday feature correctly."""
     special_days_finder = _OneSegmentSpecialDaysTransform(find_special_weekday=True, find_special_month_day=False)
     df = special_days_finder.fit_transform(df_with_specials)
-    assert (df_with_specials["week_true"] == df["anomaly_weekdays"]).all()
+    assert (df_with_specials["week_true"] == df["regressor_anomaly_weekdays"]).all()
 
 
 def test_month_feature(df_with_specials: pd.DataFrame):
     """This test checks that _OneSegmentSpecialDaysTransform computes monthday feature correctly."""
     special_days_finder = _OneSegmentSpecialDaysTransform(find_special_weekday=False, find_special_month_day=True)
     df = special_days_finder.fit_transform(df_with_specials)
-    assert (df_with_specials["month_true"] == df["anomaly_monthdays"]).all()
+    assert (df_with_specials["month_true"] == df["regressor_anomaly_monthdays"]).all()
 
 
 def test_no_false_positive_week(constant_days_df: pd.DataFrame):
     """This test checks that there is no false-positive results in week mode."""
     special_days_finder = _OneSegmentSpecialDaysTransform()
     res = special_days_finder.fit_transform(constant_days_df)
-    assert res["anomaly_weekdays"].astype("bool").sum() == 0
+    assert res["regressor_anomaly_weekdays"].astype("bool").sum() == 0
 
 
 def test_no_false_positive_month(constant_days_df: pd.DataFrame):
     """This test checks that there is no false-positive results in month mode."""
     special_days_finder = _OneSegmentSpecialDaysTransform()
     res = special_days_finder.fit_transform(constant_days_df)
-    assert res["anomaly_monthdays"].astype("bool").sum() == 0
+    assert res["regressor_anomaly_monthdays"].astype("bool").sum() == 0


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->
Add 'regressor_' prefix to transforms:
+ Lags 
+ DateTimeTransform 
+ SegmentEncoder
+ SpecialDays 

## Related Issue
<!-- Link Issue here. -->

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #74 