### PR TITLE
Add possibility to set custom `in_column` for `ConfidenceIntervalOutliersTransform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feature relevance table calculation ([#227](https://github.com/tinkoff-ai/etna-ts/pull/227))
 
 ### Changed
+- Add possibility to set custom in_column for ConfidenceIntervalOutliersTransform ([#240](https://github.com/tinkoff-ai/etna-ts/pull/240))
 
 ### Fixed
 - Fixed broken links in docs command section ([#223](https://github.com/tinkoff-ai/etna-ts/pull/223))

--- a/etna/analysis/outliers/confidence_interval_outliers.py
+++ b/etna/analysis/outliers/confidence_interval_outliers.py
@@ -14,10 +14,34 @@ if TYPE_CHECKING:
     from etna.models import SARIMAXModel
 
 
+def create_ts_by_column(ts: "TSDataset", column: str) -> "TSDataset":
+    """Create TSDataset based on original ts with selecting only column in each segment and setting it to target.
+
+    Parameters
+    ----------
+    ts:
+        dataset with timeseries data
+    column:
+        column to select in each.
+
+    Returns
+    -------
+    result: TSDataset
+        dataset with selected column.
+    """
+    from etna.datasets import TSDataset
+
+    new_df = ts[:, :, [column]]
+    new_columns_tuples = [(x[0], "target") for x in new_df.columns.tolist()]
+    new_df.columns = pd.MultiIndex.from_tuples(new_columns_tuples, names=new_df.columns.names)
+    return TSDataset(new_df, freq=ts.freq)
+
+
 def get_anomalies_confidence_interval(
     ts: "TSDataset",
     model: Union[Type["ProphetModel"], Type["SARIMAXModel"]],
     interval_width: float = 0.95,
+    in_column: str = "target",
     **model_params,
 ) -> Dict[str, List[pd.Timestamp]]:
     """
@@ -27,27 +51,37 @@ def get_anomalies_confidence_interval(
     Parameters
     ----------
     ts:
-        TSDataset with timeseries data(should contains all the necessary features).
+        dataset with timeseries data(should contains all the necessary features).
     model:
-        Model for confidence interval estimation.
+        model for confidence interval estimation.
     interval_width:
-       The significance level for the confidence interval. By default a 95% confidence interval is taken.
+        the significance level for the confidence interval. By default a 95% confidence interval is taken.
+    in_column:
+        column to analyzes
+        If it is set to "target", then all data will be used for prediction.
+        Otherwise, only column data will be used.
 
     Returns
     -------
     dict of outliers: Dict[str, List[pd.Timestamp]]
-        Dict of outliers in format {segment: [outliers_timestamps]}.
+        dict of outliers in format {segment: [outliers_timestamps]}.
 
     Notes
     -----
-    Works only with target column.
+    For not "target" column only column data will be used for learning.
     """
+    if in_column == "target":
+        ts_inner = ts
+    else:
+        ts_inner = create_ts_by_column(ts, in_column)
     outliers_per_segment = {}
     time_points = np.array(ts.index.values)
     model_instance = model(**model_params)
-    model_instance.fit(ts)
-    confidence_interval = model_instance.forecast(deepcopy(ts), confidence_interval=True, interval_width=interval_width)
-    for segment in ts.segments:
+    model_instance.fit(ts_inner)
+    confidence_interval = model_instance.forecast(
+        deepcopy(ts_inner), confidence_interval=True, interval_width=interval_width
+    )
+    for segment in ts_inner.segments:
         segment_slice = confidence_interval[:, segment, :][segment]
         anomalies_mask = (segment_slice["target"] > segment_slice["target_upper"]) | (
             segment_slice["target"] < segment_slice["target_lower"]

--- a/etna/loggers/wandb_logger.py
+++ b/etna/loggers/wandb_logger.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 
 from etna import SETTINGS
-from etna.analysis import plot_backtest_interactive
 from etna.loggers.base import BaseLogger
 
 if TYPE_CHECKING:
@@ -158,6 +157,8 @@ class WandbLogger(BaseLogger):
         fold_info_df:
             Fold information from backtest
         """
+        from etna.analysis import plot_backtest_interactive
+
         if self.table:
             self.experiment.summary["metrics"] = wandb.Table(data=metrics_df)
             self.experiment.summary["forecast"] = wandb.Table(data=self._prepare_table(forecast_df))

--- a/etna/transforms/outliers.py
+++ b/etna/transforms/outliers.py
@@ -282,6 +282,7 @@ class ConfidenceIntervalOutliersTransform(OutliersTransform):
 
     def __init__(
         self,
+        in_column: str,
         model: Union[Type["ProphetModel"], Type["SARIMAXModel"]],
         interval_width: float = 0.95,
         **model_kwargs,
@@ -290,6 +291,8 @@ class ConfidenceIntervalOutliersTransform(OutliersTransform):
 
         Parameters
         ----------
+        in_column:
+            name of processed column
         model:
             model for confidence interval estimation
         interval_width:
@@ -297,12 +300,12 @@ class ConfidenceIntervalOutliersTransform(OutliersTransform):
 
         Notes
         -----
-        Works only with target column.
+        For not "target" column only column data will be used for learning.
         """
         self.model = model
         self.interval_width = interval_width
         self.model_kwargs = model_kwargs
-        super().__init__(in_column="target")
+        super().__init__(in_column=in_column)
 
     def detect_outliers(self, ts: TSDataset) -> Dict[str, List[pd.Timestamp]]:
         """Call `get_anomalies_confidence_interval` function with self parameters.
@@ -318,7 +321,7 @@ class ConfidenceIntervalOutliersTransform(OutliersTransform):
             dict of outliers in format {segment: [outliers_timestamps]}
         """
         return get_anomalies_confidence_interval(
-            ts=ts, model=self.model, interval_width=self.interval_width, **self.model_kwargs
+            ts=ts, model=self.model, interval_width=self.interval_width, in_column=self.in_column, **self.model_kwargs
         )
 
 

--- a/tests/test_analysis/test_outliers/test_confidence_interval_outliers.py
+++ b/tests/test_analysis/test_outliers/test_confidence_interval_outliers.py
@@ -2,13 +2,38 @@ import numpy as np
 import pytest
 
 from etna.analysis import get_anomalies_confidence_interval
+from etna.analysis.outliers.confidence_interval_outliers import create_ts_by_column
+from etna.datasets import TSDataset
 from etna.models import ProphetModel
 from etna.models import SARIMAXModel
 
 
+@pytest.mark.parametrize("column", ["exog"])
+def test_create_ts_by_column_interface(outliers_tsds, column):
+    """Test that `create_ts_column` produces correct columns."""
+    new_ts = create_ts_by_column(outliers_tsds, column)
+    assert isinstance(new_ts, TSDataset)
+    assert outliers_tsds.segments == new_ts.segments
+    assert new_ts.columns.get_level_values("feature").unique().tolist() == ["target"]
+
+
+@pytest.mark.parametrize("column", ["exog"])
+def test_create_ts_by_column_retain_column(outliers_tsds, column):
+    """Test that `create_ts_column` selects correct data in selected columns."""
+    new_ts = create_ts_by_column(outliers_tsds, column)
+    for segment in new_ts.segments:
+        new_series = new_ts[:, segment, "target"]
+        original_series = outliers_tsds[:, segment, column]
+        new_series = new_series[~new_series.isna()]
+        original_series = original_series[~original_series.isna()]
+        assert np.all(new_series == original_series)
+
+
+@pytest.mark.parametrize("in_column", ["target", "exog"])
 @pytest.mark.parametrize("model", (ProphetModel, SARIMAXModel))
-def test_interface(outliers_tsds, model):
-    anomalies = get_anomalies_confidence_interval(outliers_tsds, model=model, interval_width=0.95)
+def test_get_anomalies_confidence_interval_interface(outliers_tsds, model, in_column):
+    """Test that `get_anomalies_confidence_interval` produces correct columns."""
+    anomalies = get_anomalies_confidence_interval(outliers_tsds, model=model, interval_width=0.95, in_column=in_column)
     assert isinstance(anomalies, dict)
     assert sorted(list(anomalies.keys())) == sorted(outliers_tsds.segments)
     for segment in anomalies.keys():
@@ -17,8 +42,9 @@ def test_interface(outliers_tsds, model):
             assert isinstance(date, np.datetime64)
 
 
+@pytest.mark.parametrize("in_column", ["target", "exog"])
 @pytest.mark.parametrize(
-    "model,interval_width, true_anomalies",
+    "model, interval_width, true_anomalies",
     (
         (
             ProphetModel,
@@ -28,5 +54,11 @@ def test_interface(outliers_tsds, model):
         (SARIMAXModel, 0.999, {"1": [], "2": [np.datetime64("2021-01-27")]}),
     ),
 )
-def test_confidence_interval_outliers(outliers_tsds, model, interval_width, true_anomalies):
-    assert get_anomalies_confidence_interval(outliers_tsds, model, interval_width) == true_anomalies
+def test_get_anomalies_confidence_interval_values(outliers_tsds, model, interval_width, true_anomalies, in_column):
+    """Test that `get_anomalies_confidence_interval` generates correct values."""
+    assert (
+        get_anomalies_confidence_interval(
+            outliers_tsds, model=model, interval_width=interval_width, in_column=in_column
+        )
+        == true_anomalies
+    )

--- a/tests/test_transforms/test_outliers_transform.py
+++ b/tests/test_transforms/test_outliers_transform.py
@@ -17,106 +17,110 @@ from etna.transforms import SAXOutliersTransform
 @pytest.fixture()
 def outliers_solid_tsds():
     """Create TSDataset with outliers and same last date."""
-    timestamp1 = np.arange(np.datetime64("2021-01-01"), np.datetime64("2021-02-10"))
-    target1 = [np.sin(i) for i in range(len(timestamp1))]
+    timestamp = pd.date_range("2021-01-01", end="2021-02-20", freq="D")
+    target1 = [np.sin(i) for i in range(len(timestamp))]
     target1[10] += 10
 
-    timestamp2 = np.arange(np.datetime64("2021-01-01"), np.datetime64("2021-02-10"))
-    target2 = [np.sin(i) for i in range(len(timestamp2))]
+    target2 = [np.sin(i) for i in range(len(timestamp))]
     target2[8] += 8
     target2[15] = 2
     target2[26] -= 12
 
-    df1 = pd.DataFrame({"timestamp": timestamp1, "target": target1, "segment": "1"})
-    df2 = pd.DataFrame({"timestamp": timestamp2, "target": target2, "segment": "2"})
-
+    df1 = pd.DataFrame({"timestamp": timestamp, "target": target1, "segment": "1"})
+    df2 = pd.DataFrame({"timestamp": timestamp, "target": target2, "segment": "2"})
     df = pd.concat([df1, df2], ignore_index=True)
-
-    df = df.pivot(index="timestamp", columns="segment")
-    df = df.reorder_levels([1, 0], axis=1)
-    df = df.sort_index(axis=1)
-    df.columns.names = ["segment", "feature"]
-    tsds = TSDataset(df, "1d")
-    return tsds
+    df_exog = df.copy()
+    df_exog.columns = ["timestamp", "regressor_1", "segment"]
+    ts = TSDataset(df=TSDataset.to_dataset(df).iloc[:-10], df_exog=TSDataset.to_dataset(df_exog), freq="D")
+    return ts
 
 
+@pytest.mark.parametrize("in_column", ["target", "regressor_1"])
 @pytest.mark.parametrize(
-    "transform",
+    "transform_constructor, constructor_kwargs",
     [
-        MedianOutliersTransform(in_column="target"),
-        DensityOutliersTransform(in_column="target"),
-        SAXOutliersTransform(in_column="target"),
-        ConfidenceIntervalOutliersTransform(model=ProphetModel),
+        (MedianOutliersTransform, {}),
+        (DensityOutliersTransform, {}),
+        (SAXOutliersTransform, {}),
+        (ConfidenceIntervalOutliersTransform, dict(model=ProphetModel)),
     ],
 )
-def test_interface(transform, example_tsds: TSDataset):
+def test_interface(transform_constructor, constructor_kwargs, outliers_solid_tsds: TSDataset, in_column):
     """Checks outliers transforms doesn't change structure of dataframe."""
-    start_columnns = example_tsds.columns
-    example_tsds.fit_transform(transforms=[transform])
-    assert np.all(start_columnns == example_tsds.columns)
+    transform = transform_constructor(in_column=in_column, **constructor_kwargs)
+    start_columns = outliers_solid_tsds.columns
+    outliers_solid_tsds.fit_transform(transforms=[transform])
+    assert np.all(start_columns == outliers_solid_tsds.columns)
 
 
+@pytest.mark.parametrize("in_column", ["target", "exog"])
 @pytest.mark.parametrize(
-    "transform, method, method_kwargs",
+    "transform_constructor, constructor_kwargs, method, method_kwargs",
     [
-        (MedianOutliersTransform(in_column="target"), get_anomalies_median, {}),
-        (DensityOutliersTransform(in_column="target"), get_anomalies_density, {}),
-        (SAXOutliersTransform(in_column="target"), get_sequence_anomalies, {}),
+        (MedianOutliersTransform, {}, get_anomalies_median, {}),
+        (DensityOutliersTransform, {}, get_anomalies_density, {}),
+        (SAXOutliersTransform, {}, get_sequence_anomalies, {}),
         (
-            ConfidenceIntervalOutliersTransform(model=ProphetModel),
+            ConfidenceIntervalOutliersTransform,
+            dict(model=ProphetModel),
             get_anomalies_confidence_interval,
-            {"model": ProphetModel},
+            dict(model=ProphetModel),
         ),
     ],
 )
-def test_outliers_detection(transform, method, outliers_tsds, method_kwargs):
+def test_outliers_detection(transform_constructor, constructor_kwargs, method, outliers_tsds, method_kwargs, in_column):
     """Checks that outliers transforms detect anomalies according to methods from etna.analysis."""
-    detectiom_method_results = method(outliers_tsds, **method_kwargs)
+    detection_method_results = method(outliers_tsds, in_column=in_column, **method_kwargs)
+    transform = transform_constructor(in_column=in_column, **constructor_kwargs)
 
     # save for each segment index without existing nans
     non_nan_index = {}
     for segment in outliers_tsds.segments:
-        non_nan_index[segment] = outliers_tsds[:, segment, "target"].dropna().index
+        non_nan_index[segment] = outliers_tsds[:, segment, in_column].dropna().index
     # convert to df to ignore different lengths of series
     transformed_df = transform.fit_transform(outliers_tsds.to_pandas())
     for segment in outliers_tsds.segments:
-        nan_timestamps = detectiom_method_results[segment]
-        transformed_column = transformed_df.loc[non_nan_index[segment], pd.IndexSlice[segment, "target"]]
+        nan_timestamps = detection_method_results[segment]
+        transformed_column = transformed_df.loc[non_nan_index[segment], pd.IndexSlice[segment, in_column]]
         assert np.all(transformed_column[transformed_column.isna()].index == nan_timestamps)
 
 
+@pytest.mark.parametrize("in_column", ["target", "regressor_1"])
 @pytest.mark.parametrize(
-    "transform",
+    "transform_constructor, constructor_kwargs",
     [
-        MedianOutliersTransform(in_column="target"),
-        DensityOutliersTransform(in_column="target"),
-        SAXOutliersTransform(in_column="target"),
-        ConfidenceIntervalOutliersTransform(model=ProphetModel),
+        (MedianOutliersTransform, {}),
+        (DensityOutliersTransform, {}),
+        (SAXOutliersTransform, {}),
+        (ConfidenceIntervalOutliersTransform, dict(model=ProphetModel)),
     ],
 )
-def test_inverse_transform_train(transform, outliers_solid_tsds):
+def test_inverse_transform_train(transform_constructor, constructor_kwargs, outliers_solid_tsds, in_column):
     """Checks that inverse transform returns dataset to its original form."""
+    transform = transform_constructor(in_column=in_column, **constructor_kwargs)
     original_df = outliers_solid_tsds.df.copy()
     outliers_solid_tsds.fit_transform([transform])
     outliers_solid_tsds.inverse_transform()
 
-    assert (original_df == outliers_solid_tsds.df).all().all()
+    assert np.all(original_df == outliers_solid_tsds.df)
 
 
+@pytest.mark.parametrize("in_column", ["target", "regressor_1"])
 @pytest.mark.parametrize(
-    "transform",
+    "transform_constructor, constructor_kwargs",
     [
-        MedianOutliersTransform(in_column="target"),
-        DensityOutliersTransform(in_column="target"),
-        SAXOutliersTransform(in_column="target"),
-        ConfidenceIntervalOutliersTransform(model=ProphetModel),
+        (MedianOutliersTransform, {}),
+        (DensityOutliersTransform, {}),
+        (SAXOutliersTransform, {}),
+        (ConfidenceIntervalOutliersTransform, dict(model=ProphetModel)),
     ],
 )
-def test_inverse_transform_future(transform, outliers_solid_tsds):
+def test_inverse_transform_future(transform_constructor, constructor_kwargs, outliers_solid_tsds, in_column):
     """Checks that inverse transform does not change the future."""
+    transform = transform_constructor(in_column=in_column, **constructor_kwargs)
     outliers_solid_tsds.fit_transform([transform])
     future = outliers_solid_tsds.make_future(future_steps=10)
     original_future_df = future.df.copy()
     future.inverse_transform()
-
-    assert (future.df.isnull() == original_future_df.isnull()).all().all()
+    # check equals and has nans in the same places
+    assert np.all((future.df == original_future_df) | (future.df.isna() & original_future_df.isna()))


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
See #201.

## Related Issue
#201.

## Closing issues
Closes #201.