### PR TITLE
Fix processing empty exog values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed broken links in docs command section ([#223](https://github.com/tinkoff-ai/etna-ts/pull/223))
+- Fix working TSDataset.make_future with empty exog values ([#244](https://github.com/tinkoff-ai/etna-ts/pull/244))
 
 ## [1.2.0] - 2021-10-27
 ### Added

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -220,8 +220,8 @@ class TSDataset:
         return future_ts
 
     @staticmethod
-    def _check_exog(df: pd.DataFrame, df_exog: pd.DataFrame):
-        """Check that df_exog have more timestamps than df."""
+    def _check_regressors(df: pd.DataFrame, df_exog: pd.DataFrame):
+        """Check that regressors in df_exog begin not later than in df and end later than in df."""
         df_segments = df.columns.get_level_values("segment")
         for segment in df_segments:
             target = df[segment]["target"].dropna()
@@ -242,8 +242,8 @@ class TSDataset:
                     )
 
     def _merge_exog(self, df: pd.DataFrame) -> pd.DataFrame:
-        self._check_exog(df=df, df_exog=self.df_exog)
-        df = pd.merge(df, self.df_exog, left_index=True, right_index=True).sort_index(axis=1, level=(0, 1))
+        self._check_regressors(df=df, df_exog=self.df_exog)
+        df = pd.merge(df, self.df_exog, left_index=True, right_index=True, how="left").sort_index(axis=1, level=(0, 1))
         return df
 
     def _check_endings(self):


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
* add tests on `make_future`, 
* change how option in `merge_exog`, 
* rename `_check_exog` to `_check_regressors`

## Related Issue
#239.

## Closing issues
Closes #239.