### PR TITLE
Fix default value for `TSDataset.tail`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed broken links in docs command section ([#223](https://github.com/tinkoff-ai/etna-ts/pull/223))
+- Fix default value for TSDataset.tail ([#245](https://github.com/tinkoff-ai/etna-ts/pull/245))
 
 ## [1.2.0] - 2021-10-27
 ### Added

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -681,7 +681,7 @@ class TSDataset:
         """
         return self.df.head(n_rows)
 
-    def tail(self, n_rows: Optional[int] = None) -> pd.DataFrame:
+    def tail(self, n_rows: int = 5) -> pd.DataFrame:
         """Return the last `n` rows.
 
         Mimics pandas method.

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -351,6 +351,14 @@ def test_finding_regressors(df_and_regressors):
     assert sorted(ts.regressors) == ["regressor_1", "regressor_2"]
 
 
+def test_head_default(tsdf_with_exog):
+    assert np.all(tsdf_with_exog.head() == tsdf_with_exog.df.head())
+
+
+def test_tail_default(tsdf_with_exog):
+    np.all(tsdf_with_exog.tail() == tsdf_with_exog.df.tail())
+
+
 def test_updating_regressors_fit_transform(df_and_regressors):
     """Check that ts.regressors is updated after making ts.fit_transform()."""
     df, df_exog = df_and_regressors


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
* fix default value for TSDataset.tail, 
* add tests on TSDataset.head and TSDataset.tail with default parameters

## Related Issue
#237.

## Closing issues
Closes #237.