### PR TITLE
Make `in_column` the first argument in every transform 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Add possibility to set custom in_column for ConfidenceIntervalOutliersTransform ([#240](https://github.com/tinkoff-ai/etna-ts/pull/240))
+- Make `in_column` the first argument in every transform ([#247](https://github.com/tinkoff-ai/etna-ts/pull/247))
 
 ### Fixed
 - Fixed broken links in docs command section ([#223](https://github.com/tinkoff-ai/etna-ts/pull/223))

--- a/etna/transforms/add_constant.py
+++ b/etna/transforms/add_constant.py
@@ -5,21 +5,21 @@ from etna.transforms.base import Transform
 
 
 class _OneSegmentAddConstTransform(Transform):
-    def __init__(self, value: float, in_column: str, inplace: bool = True):
+    def __init__(self, in_column: str, value: float,  inplace: bool = True):
         """
         Init _OneSegmentAddConstTransform.
 
         Parameters
         ----------
-        value:
-            value that should be added to the series
         in_column:
             column to apply transform
+        value:
+            value that should be added to the series
         inplace:
             if True, apply add constant transformation inplace to in_column, if False, add column {in_column}_add_{value} to dataset
         """
-        self.value = value
         self.in_column = in_column
+        self.value = value
         self.inplace = inplace
         self.out_column = self.in_column if self.inplace else f"{self.in_column}_add_{self.value}"
 
@@ -72,24 +72,24 @@ class _OneSegmentAddConstTransform(Transform):
 class AddConstTransform(PerSegmentWrapper):
     """AddConstTransform add constant for given series."""
 
-    def __init__(self, value: float, in_column: str, inplace: bool = True):
+    def __init__(self, in_column: str, value: float, inplace: bool = True):
         """
         Init AddConstTransform.
 
         Parameters
         ----------
-        value:
-            value that should be added to the series
         in_column:
             column to apply transform
+        value:
+            value that should be added to the series
         inplace:
             if True, apply add constant transformation inplace to in_column, if False, add column {in_column}_add_{value} to dataset
         """
-        self.value = value
         self.in_column = in_column
+        self.value = value
         self.inplace = inplace
         super().__init__(
-            transform=_OneSegmentAddConstTransform(value=self.value, in_column=self.in_column, inplace=self.inplace)
+            transform=_OneSegmentAddConstTransform(in_column=self.in_column, value=self.value, inplace=self.inplace)
         )
 
 

--- a/etna/transforms/add_constant.py
+++ b/etna/transforms/add_constant.py
@@ -5,7 +5,7 @@ from etna.transforms.base import Transform
 
 
 class _OneSegmentAddConstTransform(Transform):
-    def __init__(self, in_column: str, value: float,  inplace: bool = True):
+    def __init__(self, in_column: str, value: float, inplace: bool = True):
         """
         Init _OneSegmentAddConstTransform.
 

--- a/etna/transforms/lags.py
+++ b/etna/transforms/lags.py
@@ -44,6 +44,7 @@ class LagTransform(PerSegmentWrapper):
             name of processed column
         lags:
             int value or list of values for lags computation; if int, generate range of lags from 1 to given value
+
         Raises
         ------
         ValueError:

--- a/etna/transforms/lags.py
+++ b/etna/transforms/lags.py
@@ -8,7 +8,8 @@ from etna.transforms.base import Transform
 
 
 class _OneSegmentLagFeature(Transform):
-    def __init__(self, lags: Union[List[int], int], in_column: str):
+    def __init__(self, in_column: str, lags: Union[List[int], int]):
+        self.in_column = in_column
         if isinstance(lags, int):
             if lags < 1:
                 raise ValueError(f"{type(self).__name__} works only with positive lags values, {lags} given")
@@ -18,7 +19,6 @@ class _OneSegmentLagFeature(Transform):
                 raise ValueError(f"{type(self).__name__} works only with positive lags values")
             self.lags = lags
 
-        self.in_column = in_column
         self.out_postfix = "_lag"
         self.out_prefix = "regressor_"
 
@@ -35,21 +35,20 @@ class _OneSegmentLagFeature(Transform):
 class LagTransform(PerSegmentWrapper):
     """Generates series of lags from given dataframe. Creates columns 'regressor_<column>_lag_<number>'."""
 
-    def __init__(self, lags: Union[List[int], int], in_column: str):
+    def __init__(self, in_column: str, lags: Union[List[int], int]):
         """Create instance of LagTransform.
 
         Parameters
         ----------
-        lags:
-            int value or list of values for lags computation; if int, generate range of lags from 1 to given value
         in_column:
             name of processed column
-
+        lags:
+            int value or list of values for lags computation; if int, generate range of lags from 1 to given value
         Raises
         ------
         ValueError:
             if lags value contains non-positive values
         """
-        self.lags = lags
         self.in_column = in_column
-        super().__init__(transform=_OneSegmentLagFeature(lags=self.lags, in_column=self.in_column))
+        self.lags = lags
+        super().__init__(transform=_OneSegmentLagFeature(in_column=self.in_column, lags=self.lags))

--- a/etna/transforms/scalers.py
+++ b/etna/transforms/scalers.py
@@ -50,8 +50,8 @@ class StandardScalerTransform(SklearnTransform):
             if incorrect mode given
         """
         super().__init__(
-            transformer=StandardScaler(with_mean=with_mean, with_std=with_std, copy=True),
             in_column=in_column,
+            transformer=StandardScaler(with_mean=with_mean, with_std=with_std, copy=True),
             inplace=inplace,
             mode=mode,
         )

--- a/etna/transforms/sklearn.py
+++ b/etna/transforms/sklearn.py
@@ -22,8 +22,8 @@ class SklearnTransform(Transform):
 
     def __init__(
         self,
+        in_column: Union[str, List[str]],
         transformer: TransformerMixin,
-        in_column: Optional[Union[str, List[str]]] = None,
         inplace: bool = True,
         mode: Union[TransformMode, str] = "per-segment",
     ):
@@ -32,10 +32,10 @@ class SklearnTransform(Transform):
 
         Parameters
         ----------
-        transformer:
-            sklearn.base.TransformerMixin instance.
         in_column:
             columns to be transformed, if None - all columns will be scaled.
+        transformer:
+            sklearn.base.TransformerMixin instance.
         inplace:
             features are changed by transformed.
         mode:

--- a/etna/transforms/statistics.py
+++ b/etna/transforms/statistics.py
@@ -15,8 +15,8 @@ class WindowStatisticsTransform(Transform, ABC):
 
     def __init__(
         self,
-        window: int,
         in_column: str,
+        window: int,
         seasonality: int = 1,
         min_periods: int = 1,
         out_postfix: Optional[str] = None,
@@ -27,6 +27,8 @@ class WindowStatisticsTransform(Transform, ABC):
 
         Parameters
         ----------
+        in_column: str
+            name of processed column
         window: int
             size of window to aggregate
         seasonality: int
@@ -39,6 +41,7 @@ class WindowStatisticsTransform(Transform, ABC):
         fillna: float
             value to fill results NaNs with
         """
+        self.in_column = in_column
         self.window = window
         self.seasonality = seasonality
         self.min_periods = min_periods
@@ -47,7 +50,6 @@ class WindowStatisticsTransform(Transform, ABC):
         self.kwargs = kwargs
         self.min_required_len = max(self.min_periods - 1, 0) * self.seasonality + 1
         self.history = self.window * self.seasonality
-        self.in_column = in_column
 
     def fit(self, *args) -> "WindowStatisticsTransform":
         """Fits transform."""
@@ -111,8 +113,8 @@ class MeanTransform(WindowStatisticsTransform):
 
     def __init__(
         self,
-        window: int,
         in_column: str,
+        window: int,
         seasonality: int = 1,
         alpha: float = 1,
         min_periods: int = 1,
@@ -123,6 +125,8 @@ class MeanTransform(WindowStatisticsTransform):
 
         Parameters
         ----------
+        in_column: str
+            name of processed column
         window: int
             size of window to aggregate
         seasonality: int
@@ -138,8 +142,8 @@ class MeanTransform(WindowStatisticsTransform):
             value to fill results NaNs with
         """
         super().__init__(
-            window=window,
             in_column=in_column,
+            window=window,
             seasonality=seasonality,
             min_periods=min_periods,
             out_postfix=out_postfix,
@@ -196,9 +200,9 @@ class QuantileTransform(WindowStatisticsTransform):
 
     def __init__(
         self,
+        in_column: str,
         quantile: float,
         window: int,
-        in_column: str,
         seasonality: int = 1,
         min_periods: int = 1,
         out_postfix: Optional[str] = None,
@@ -208,6 +212,8 @@ class QuantileTransform(WindowStatisticsTransform):
 
         Parameters
         ----------
+        in_column: str
+            name of processed column
         quantile: float
             quantile to calculate
         window: int
@@ -224,8 +230,8 @@ class QuantileTransform(WindowStatisticsTransform):
         """
         self.quantile = quantile
         super().__init__(
-            window=window,
             in_column=in_column,
+            window=window,
             seasonality=seasonality,
             min_periods=min_periods,
             out_postfix=out_postfix,

--- a/tests/test_transforms/test_lag_transform.py
+++ b/tests/test_transforms/test_lag_transform.py
@@ -41,7 +41,7 @@ def test_repr():
     lags = list(range(8, 24, 1))
     transform = LagTransform(lags=lags, in_column="target")
     transform_repr = transform.__repr__()
-    true_repr = f"{transform_class_repr}(lags = {lags}, in_column = 'target', )"
+    true_repr = f"{transform_class_repr}(in_column = 'target', lags = {lags}, )"
     assert transform_repr == true_repr
 
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->
Make `in_column` the first argument in every transform 
## Related Issue
<!-- Link Issue here. -->

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #215 