### PR TITLE
Fix issue with `aggregate_metics=True` for `ConsoleLogger` and `WandbLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed broken links in docs command section ([#223](https://github.com/tinkoff-ai/etna-ts/pull/223))
 - Fix default value for TSDataset.tail ([#245](https://github.com/tinkoff-ai/etna-ts/pull/245))
 - Fix working TSDataset.make_future with empty exog values ([#244](https://github.com/tinkoff-ai/etna-ts/pull/244))
+- Fix issue with aggregate_metics=True for ConsoleLogger and WandbLogger ([#254](https://github.com/tinkoff-ai/etna-ts/pull/254))
 
 ## [1.2.0] - 2021-10-27
 ### Added

--- a/etna/loggers/console_logger.py
+++ b/etna/loggers/console_logger.py
@@ -50,15 +50,22 @@ class ConsoleLogger(BaseLogger):
         ts:
             TSDataset to with backtest data
         metrics_df:
-            Dataframe produced with TimeSeriesCrossValidation.get_metrics(aggregate_metrics=False)
+            Dataframe produced with Pipeline._get_backtest_metrics() or TimeSeriesCrossValidation.get_metrics()
         forecast_df:
             Forecast from backtest
         fold_info_df:
             Fold information from backtest
+
+        Notes
+        -----
+        The result of logging will be different for aggregate_metrics=True and aggregate_metrics=False
         """
         for _, row in metrics_df.iterrows():
             for metric in metrics_df.columns[1:-1]:
-                msg = f'Fold {row["fold_number"]}:{row["segment"]}:{metric} = {row[metric]}'
+                if "fold_number" in row:
+                    msg = f'Fold {row["fold_number"]}:{row["segment"]}:{metric} = {row[metric]}'
+                else:
+                    msg = f'Segment {row["segment"]}:{metric} = {row[metric]}'
                 self.logger.info(msg)
 
     @property

--- a/etna/loggers/console_logger.py
+++ b/etna/loggers/console_logger.py
@@ -62,8 +62,10 @@ class ConsoleLogger(BaseLogger):
         """
         for _, row in metrics_df.iterrows():
             for metric in metrics_df.columns[1:-1]:
+                # case for aggregate_metrics=False
                 if "fold_number" in row:
                     msg = f'Fold {row["fold_number"]}:{row["segment"]}:{metric} = {row[metric]}'
+                # case for aggregate_metrics=True
                 else:
                     msg = f'Segment {row["segment"]}:{metric} = {row[metric]}'
                 self.logger.info(msg)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
1. Fix `ConsoleLogger` to work with `aggregate_metrics=True`
2. Fix `WandbLogger` to work with `aggregate_metrics=True`

## Related Issue
#216.

## Closing issues
Closes #216.